### PR TITLE
Feat/#127 ManiaDB API 를 사용하여 등록되지 않은 노래 검색 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // WebClient Dependency
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // XML parsing Dependency
+    implementation 'org.glassfish.jaxb:jaxb-runtime'
+
     compileOnly 'org.projectlombok:lombok'
 
     runtimeOnly 'com.h2database:h2'
@@ -36,6 +42,9 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'
+
+    // WebClient Test Dependencies
+    testImplementation 'com.squareup.okhttp3:mockwebserver'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/shook/shook/song/application/ManiaDBSearchService.java
+++ b/backend/src/main/java/shook/shook/song/application/ManiaDBSearchService.java
@@ -1,0 +1,70 @@
+package shook.shook.song.application;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import shook.shook.song.application.dto.UnregisteredSongSearchResponse;
+import shook.shook.song.application.dto.maniadb.ManiaDBAPISearchResponse;
+import shook.shook.song.application.dto.maniadb.UnregisteredSongResponses;
+import shook.shook.song.exception.UnregisteredSongException;
+import shook.shook.song.exception.UnregisteredSongException.EmptyResultException;
+
+@RequiredArgsConstructor
+@Service
+public class ManiaDBSearchService {
+
+    private static final String MANIA_DB_API_URI = "/%s/?sr=song&display=%d&key=example&v=0.5";
+    private static final int SEARCH_SIZE = 100;
+    private static final String SPECIAL_MARK_REGEX = "[^ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9,. ]";
+    private final WebClient webClient;
+
+    public List<UnregisteredSongSearchResponse> searchSongs(final String searchWord) {
+        final String parsedSearchWord = replaceSpecialMark(searchWord);
+        final UnregisteredSongResponses searchResult = getSearchResult(parsedSearchWord);
+
+        if (Objects.isNull(searchResult.getSongs())) {
+            return Collections.emptyList();
+        }
+
+        return searchResult.getSongs().stream()
+            .map(UnregisteredSongSearchResponse::from)
+            .toList();
+    }
+
+    private String replaceSpecialMark(final String rawSearchWord) {
+        return rawSearchWord.replaceAll(SPECIAL_MARK_REGEX, "");
+    }
+
+    private UnregisteredSongResponses getSearchResult(final String searchWord) {
+        final String searchUrl = String.format(MANIA_DB_API_URI, searchWord, SEARCH_SIZE);
+        final ManiaDBAPISearchResponse result = getResultFromManiaDB(searchUrl);
+
+        if (Objects.isNull(result)) {
+            throw new EmptyResultException();
+        }
+
+        return result.getSongs();
+    }
+
+    private ManiaDBAPISearchResponse getResultFromManiaDB(final String searchUrl) {
+        return webClient.get()
+            .uri(searchUrl)
+            .accept(MediaType.TEXT_XML)
+            .acceptCharset(StandardCharsets.UTF_8)
+            .retrieve()
+            .onStatus(HttpStatusCode::is4xxClientError, (clientResponse) -> {
+                throw new UnregisteredSongException.ManiaDBClientException();
+            })
+            .onStatus(HttpStatusCode::is5xxServerError, (clientResponse) -> {
+                throw new UnregisteredSongException.ManiaDBServerException();
+            })
+            .bodyToMono(ManiaDBAPISearchResponse.class)
+            .block();
+    }
+}

--- a/backend/src/main/java/shook/shook/song/application/dto/UnregisteredSongSearchResponse.java
+++ b/backend/src/main/java/shook/shook/song/application/dto/UnregisteredSongSearchResponse.java
@@ -1,0 +1,45 @@
+package shook.shook.song.application.dto;
+
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import shook.shook.song.application.dto.maniadb.SongArtistResponse;
+
+@AllArgsConstructor
+@Getter
+public class UnregisteredSongSearchResponse {
+
+    private static final String EMPTY_SINGER = "";
+    private static final String SINGER_DELIMITER = ", ";
+    private String title;
+    private String singer;
+    private String albumImageUrl;
+
+    public static UnregisteredSongSearchResponse from(
+        final shook.shook.song.application.dto.maniadb.UnregisteredSongResponse unregisteredSongResponse) {
+        if (unregisteredSongResponse.getTrackArtists() == null
+            || unregisteredSongResponse.getTrackArtists().getArtists() == null) {
+            return new UnregisteredSongSearchResponse(
+                unregisteredSongResponse.getTitle().trim(),
+                EMPTY_SINGER,
+                unregisteredSongResponse.getAlbum().getImage().trim()
+            );
+        }
+
+        final String singers = collectToString(unregisteredSongResponse);
+
+        return new UnregisteredSongSearchResponse(
+            unregisteredSongResponse.getTitle().trim(),
+            singers,
+            unregisteredSongResponse.getAlbum().getImage().trim()
+        );
+    }
+
+    private static String collectToString(
+        final shook.shook.song.application.dto.maniadb.UnregisteredSongResponse unregisteredSongResponse) {
+        return unregisteredSongResponse.getTrackArtists().getArtists().stream()
+            .map(SongArtistResponse::getName)
+            .map(String::trim)
+            .collect(Collectors.joining(SINGER_DELIMITER));
+    }
+}

--- a/backend/src/main/java/shook/shook/song/application/dto/maniadb/ManiaDBAPISearchResponse.java
+++ b/backend/src/main/java/shook/shook/song/application/dto/maniadb/ManiaDBAPISearchResponse.java
@@ -1,0 +1,13 @@
+package shook.shook.song.application.dto.maniadb;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Getter;
+
+@Getter
+@XmlRootElement(name = "rss")
+public class ManiaDBAPISearchResponse {
+
+    @XmlElement(name = "channel")
+    private UnregisteredSongResponses songs;
+}

--- a/backend/src/main/java/shook/shook/song/application/dto/maniadb/SongAlbumResponse.java
+++ b/backend/src/main/java/shook/shook/song/application/dto/maniadb/SongAlbumResponse.java
@@ -1,0 +1,13 @@
+package shook.shook.song.application.dto.maniadb;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Getter;
+
+@Getter
+@XmlRootElement(name = "album", namespace = "http://www.maniadb.com/api")
+public class SongAlbumResponse {
+
+    @XmlElement(name = "image")
+    private String image;
+}

--- a/backend/src/main/java/shook/shook/song/application/dto/maniadb/SongArtistResponse.java
+++ b/backend/src/main/java/shook/shook/song/application/dto/maniadb/SongArtistResponse.java
@@ -1,0 +1,13 @@
+package shook.shook.song.application.dto.maniadb;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Getter;
+
+@Getter
+@XmlRootElement(name = "artist", namespace = "http://www.maniadb.com/api")
+public class SongArtistResponse {
+
+    @XmlElement(name = "name")
+    private String name;
+}

--- a/backend/src/main/java/shook/shook/song/application/dto/maniadb/SongTrackArtistsResponse.java
+++ b/backend/src/main/java/shook/shook/song/application/dto/maniadb/SongTrackArtistsResponse.java
@@ -1,0 +1,14 @@
+package shook.shook.song.application.dto.maniadb;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+@XmlRootElement(name = "trackartists", namespace = "http://www.maniadb.com/api")
+public class SongTrackArtistsResponse {
+
+    @XmlElement(name = "artist", namespace = "http://www.maniadb.com/api")
+    private List<SongArtistResponse> artists;
+}

--- a/backend/src/main/java/shook/shook/song/application/dto/maniadb/UnregisteredSongResponse.java
+++ b/backend/src/main/java/shook/shook/song/application/dto/maniadb/UnregisteredSongResponse.java
@@ -1,0 +1,19 @@
+package shook.shook.song.application.dto.maniadb;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Getter;
+
+@Getter
+@XmlRootElement(name = "item")
+public class UnregisteredSongResponse {
+
+    @XmlElement(name = "title")
+    private String title;
+
+    @XmlElement(name = "trackartists", namespace = "http://www.maniadb.com/api")
+    private SongTrackArtistsResponse trackArtists;
+
+    @XmlElement(name = "album", namespace = "http://www.maniadb.com/api")
+    private SongAlbumResponse album;
+}

--- a/backend/src/main/java/shook/shook/song/application/dto/maniadb/UnregisteredSongResponses.java
+++ b/backend/src/main/java/shook/shook/song/application/dto/maniadb/UnregisteredSongResponses.java
@@ -1,0 +1,14 @@
+package shook.shook.song.application.dto.maniadb;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+@XmlRootElement(name = "channel")
+public class UnregisteredSongResponses {
+
+    @XmlElement(name = "item")
+    private List<UnregisteredSongResponse> songs;
+}

--- a/backend/src/main/java/shook/shook/song/config/ManiaDBConfiguration.java
+++ b/backend/src/main/java/shook/shook/song/config/ManiaDBConfiguration.java
@@ -1,0 +1,30 @@
+package shook.shook.song.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.codec.xml.Jaxb2XmlDecoder;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class ManiaDBConfiguration {
+
+    private static final String MANIA_DB_BASE_URL = "http://www.maniadb.com/api/search";
+
+    @Bean
+    public WebClient getWebClient() {
+        return WebClient.builder()
+            .baseUrl(MANIA_DB_BASE_URL)
+            .exchangeStrategies(
+                ExchangeStrategies.builder()
+                    .codecs(configurer ->
+                        configurer.defaultCodecs().jaxb2Decoder(new Jaxb2XmlDecoder())
+                    )
+                    .codecs(configurer ->
+                        configurer.defaultCodecs().maxInMemorySize(4 * 1024 * 1024)
+                    )
+                    .build()
+            )
+            .build();
+    }
+}

--- a/backend/src/main/java/shook/shook/song/exception/UnregisteredSongException.java
+++ b/backend/src/main/java/shook/shook/song/exception/UnregisteredSongException.java
@@ -1,0 +1,25 @@
+package shook.shook.song.exception;
+
+public class UnregisteredSongException extends RuntimeException {
+
+    public static class EmptyResultException extends UnregisteredSongException {
+
+        public EmptyResultException() {
+            super();
+        }
+    }
+
+    public static class ManiaDBServerException extends UnregisteredSongException {
+
+        public ManiaDBServerException() {
+            super();
+        }
+    }
+
+    public static class ManiaDBClientException extends UnregisteredSongException {
+
+        public ManiaDBClientException() {
+            super();
+        }
+    }
+}

--- a/backend/src/main/java/shook/shook/song/ui/ManiaDBApiController.java
+++ b/backend/src/main/java/shook/shook/song/ui/ManiaDBApiController.java
@@ -1,0 +1,29 @@
+package shook.shook.song.ui;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import shook.shook.song.application.ManiaDBSearchService;
+import shook.shook.song.application.dto.UnregisteredSongSearchResponse;
+
+@RequiredArgsConstructor
+@RequestMapping("/songs/unregistered/search")
+@RestController
+public class ManiaDBApiController {
+
+    private final ManiaDBSearchService maniaDBSearchService;
+
+    @GetMapping
+    public ResponseEntity<List<UnregisteredSongSearchResponse>> searchUnregisteredSong(
+        final @RequestParam("keyword") String searchWord
+    ) {
+        final List<UnregisteredSongSearchResponse> songs = maniaDBSearchService.searchSongs(
+            searchWord);
+
+        return ResponseEntity.ok(songs);
+    }
+}

--- a/backend/src/test/java/shook/shook/song/application/ManiaDBSearchServiceTest.java
+++ b/backend/src/test/java/shook/shook/song/application/ManiaDBSearchServiceTest.java
@@ -1,0 +1,396 @@
+package shook.shook.song.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.xml.Jaxb2XmlDecoder;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import shook.shook.song.application.dto.UnregisteredSongSearchResponse;
+import shook.shook.song.exception.UnregisteredSongException;
+import shook.shook.song.exception.UnregisteredSongException.EmptyResultException;
+
+@ExtendWith(MockitoExtension.class)
+class ManiaDBSearchServiceTest {
+
+    private static final String SEARCH_WORD = "흔들리는꽃속에서네샴푸향이느껴진거야";
+    private static final String SPECIAL_MARK_SEARCH_WORD = "\b흔%들리는꽃*들속@에서네샴/푸향이+느껴진-거야!\t";
+    private static final String SEARCH_RESULT = """
+        <?xml version="1.0" encoding="utf-8" ?>
+        <rss version="2.0" xmlns:maniadb="http://www.maniadb.com/api" >
+            <channel>
+                <title>
+                    <![CDATA[Maniadb Open API v0.5 : Search song for "흔들리는꽃속에서네샴푸향이느껴진거야"]]>
+                </title>
+                <link>www.maniadb.com</link>
+                <description>
+                    <![CDATA[Maniadb Open API v0.5 : Search song for "흔들리는꽃속에서네샴푸향이느껴진거야"]]>
+                </description>
+                <lastBuildDate>Fri, 28 Jul 2023 12:03:53 +0900</lastBuildDate>
+                <total>1</total>
+                <start>1</start>
+                <display>100</display>
+                <maniadb:urlbase>
+                    <![CDATA[http://www.maniadb.com/album/]]>
+                </maniadb:urlbase>
+                <item id="7557899">
+                    <title>
+                        <![CDATA[흔들리는 꽃들 속에서 네 샴푸향이 느껴진거야]]>
+                    </title>
+                    <runningtime>
+                        <![CDATA[-]]>
+                    </runningtime>
+                    <link>
+                        <![CDATA[http://www.maniadb.com/album/777829/?ss=7557899]]>
+                    </link>
+                    <pubDate>
+                        <![CDATA[Fri, 28 Jul 2023 12:03:53 +0900]]>
+                    </pubDate>
+                    <author>
+                        <![CDATA[maniadb]]>
+                    </author>
+                    <description>
+                        <![CDATA[]]>
+                    </description>
+                    <guid>
+                        <![CDATA[http://www.maniadb.com/album/777829/?ss=7557899]]>
+                    </guid>
+                    <comments>
+                        <![CDATA[http://www.maniadb.com/album/777829/?ss=7557899#TALK]]>
+                    </comments>
+                    <maniadb:album>
+                        <title>
+                            <![CDATA[멜로가 체질 by 김태성 [ost] (2019)]]>
+                        </title>
+                        <release>
+                            <![CDATA[]]>
+                        </release>
+                        <link>
+                            <![CDATA[http://www.maniadb.com/album/777829]]>
+                        </link>
+                        <image>
+                            <![CDATA[http://i.maniadb.com/images/album/777/777829_1_f.jpg]]>
+                        </image>
+                        <description>
+                            <![CDATA[]]>
+                        </description>
+                    </maniadb:album>
+                    <maniadb:artist status="DEPRECATED">
+                        <link>
+                            <![CDATA[www.maniadb.com/artist/394170]]>
+                        </link>
+                        <name>
+                            <![CDATA[장범준]]>
+                        </name>
+                    </maniadb:artist>
+                    <maniadb:trackartists>
+                        <maniadb:artist id="394170">
+                            <id>
+                                <![CDATA[394170]]>
+                            </id>
+                            <name>
+                                <![CDATA[장범준]]>
+                            </name>
+                        </maniadb:artist>
+                    </maniadb:trackartists>
+                    <maniadb:trackartistlist status="DEPRECATED">
+                        <![CDATA[장범준]]>
+                    </maniadb:trackartistlist>
+                </item>
+            </channel>
+        </rss>""";
+
+    private static final String EMPTY_RESULT_SEARCH_WORD = "빈값검색";
+    private static final String EMPTY_RESULT = """
+        <?xml version="1.0" encoding="utf-8" ?>
+        <rss version="2.0" xmlns:maniadb="http://www.maniadb.com/api" >
+            <channel>
+                <title>
+                    <![CDATA[Maniadb Open API v0.5 : Search song for "빈값검색"]]>
+                </title>
+                <link>www.maniadb.com</link>
+                <description>
+                    <![CDATA[Maniadb Open API v0.5 : Search song for "빈값검색"]]>
+                </description>
+                <lastBuildDate>Fri, 28 Jul 2023 17:37:01 +0900</lastBuildDate>
+                <total>0</total>
+                <start>1</start>
+                <display>100</display>
+                <maniadb:urlbase>
+                    <![CDATA[http://www.maniadb.com/album/]]>
+                </maniadb:urlbase>
+            </channel>
+        </rss>
+        """;
+
+    private static final String EMPTY_SINGER_SEARCH_RESULT = """
+        <?xml version="1.0" encoding="utf-8" ?>
+        <rss version="2.0" xmlns:maniadb="http://www.maniadb.com/api" >
+            <channel>
+                <title>
+                    <![CDATA[Maniadb Open API v0.5 : Search song for "흔들리는꽃속에서네샴푸향이느껴진거야"]]>
+                </title>
+                <link>www.maniadb.com</link>
+                <description>
+                    <![CDATA[Maniadb Open API v0.5 : Search song for "흔들리는꽃속에서네샴푸향이느껴진거야"]]>
+                </description>
+                <lastBuildDate>Fri, 28 Jul 2023 12:03:53 +0900</lastBuildDate>
+                <total>1</total>
+                <start>1</start>
+                <display>100</display>
+                <maniadb:urlbase>
+                    <![CDATA[http://www.maniadb.com/album/]]>
+                </maniadb:urlbase>
+                <item id="7557899">
+                    <title>
+                        <![CDATA[흔들리는 꽃들 속에서 네 샴푸향이 느껴진거야]]>
+                    </title>
+                    <runningtime>
+                        <![CDATA[-]]>
+                    </runningtime>
+                    <link>
+                        <![CDATA[http://www.maniadb.com/album/777829/?ss=7557899]]>
+                    </link>
+                    <pubDate>
+                        <![CDATA[Fri, 28 Jul 2023 12:03:53 +0900]]>
+                    </pubDate>
+                    <author>
+                        <![CDATA[maniadb]]>
+                    </author>
+                    <description>
+                        <![CDATA[]]>
+                    </description>
+                    <guid>
+                        <![CDATA[http://www.maniadb.com/album/777829/?ss=7557899]]>
+                    </guid>
+                    <comments>
+                        <![CDATA[http://www.maniadb.com/album/777829/?ss=7557899#TALK]]>
+                    </comments>
+                    <maniadb:album>
+                        <title>
+                            <![CDATA[멜로가 체질 by 김태성 [ost] (2019)]]>
+                        </title>
+                        <release>
+                            <![CDATA[]]>
+                        </release>
+                        <link>
+                            <![CDATA[http://www.maniadb.com/album/777829]]>
+                        </link>
+                        <image>
+                            <![CDATA[http://i.maniadb.com/images/album/777/777829_1_f.jpg]]>
+                        </image>
+                        <description>
+                            <![CDATA[]]>
+                        </description>
+                    </maniadb:album>
+                    <maniadb:artist status="DEPRECATED">
+                    </maniadb:artist>
+                    <maniadb:trackartists>
+                    </maniadb:trackartists>
+                    <maniadb:trackartistlist status="DEPRECATED">
+                    </maniadb:trackartistlist>
+                </item>
+            </channel>
+        </rss>""";
+
+    private static final String EMPTY_STRING = "";
+
+    private MockWebServer mockServer;
+    private ManiaDBSearchService maniaDBSearchService;
+
+    @BeforeEach
+    void startServer() {
+        mockServer = new MockWebServer();
+        maniaDBSearchService = new ManiaDBSearchService(
+            WebClient.builder()
+                .baseUrl(mockServer.url("/")
+                    .toString())
+                .exchangeStrategies(
+                    ExchangeStrategies.builder()
+                        .codecs(configurer ->
+                            configurer.defaultCodecs().jaxb2Decoder(new Jaxb2XmlDecoder())
+                        )
+                        .codecs(configurer ->
+                            configurer.defaultCodecs().maxInMemorySize(4 * 1024 * 1024)
+                        )
+                        .build()
+                )
+                .build()
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockServer.shutdown();
+    }
+
+    @DisplayName("검색 요청을 보내면 XML 응답을 정상적으로 받고, 파싱한 데이터를 응답한다.")
+    @Test
+    void search() {
+        // given
+        mockServer.enqueue(new MockResponse()
+            .setResponseCode(HttpStatus.OK.value())
+            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_XML)
+            .addHeader(HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8)
+            .setBody(SEARCH_RESULT)
+        );
+
+        final UnregisteredSongSearchResponse expectedResponse = new UnregisteredSongSearchResponse(
+            "흔들리는 꽃들 속에서 네 샴푸향이 느껴진거야",
+            "장범준",
+            "http://i.maniadb.com/images/album/777/777829_1_f.jpg"
+        );
+
+        // when
+        final List<UnregisteredSongSearchResponse> responses =
+            maniaDBSearchService.searchSongs(SEARCH_WORD);
+
+        // then
+        assertAll(
+            () -> assertThat(responses).hasSize(1),
+            () -> assertThat(responses.get(0)).usingRecursiveComparison()
+                .isEqualTo(expectedResponse)
+        );
+    }
+
+    @DisplayName("특수문자가 포함된 검색 단어가 입력된 경우, 특수문자를 제거하고 검색한다.")
+    @Test
+    void searchBySpecialMarkSearchWord() {
+        // given
+        mockServer.enqueue(new MockResponse()
+            .setResponseCode(HttpStatus.OK.value())
+            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_XML)
+            .addHeader(HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8)
+            .setBody(SEARCH_RESULT)
+        );
+
+        final UnregisteredSongSearchResponse expectedResponse = new UnregisteredSongSearchResponse(
+            "흔들리는 꽃들 속에서 네 샴푸향이 느껴진거야",
+            "장범준",
+            "http://i.maniadb.com/images/album/777/777829_1_f.jpg"
+        );
+
+        // when
+        final List<UnregisteredSongSearchResponse> responses =
+            maniaDBSearchService.searchSongs(SPECIAL_MARK_SEARCH_WORD);
+
+        // then
+        assertAll(
+            () -> assertThat(responses).hasSize(1),
+            () -> assertThat(responses.get(0)).usingRecursiveComparison()
+                .isEqualTo(expectedResponse)
+        );
+    }
+
+    @DisplayName("XML 응답에 노래가 존재하지 않으면 빈 리스트를 리턴한다.")
+    @Test
+    void searchResultReturnEmptyList() {
+        // given
+        mockServer.enqueue(new MockResponse()
+            .setResponseCode(HttpStatus.OK.value())
+            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_XML)
+            .addHeader(HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8)
+            .setBody(EMPTY_RESULT)
+        );
+
+        // when
+        final List<UnregisteredSongSearchResponse> responses =
+            maniaDBSearchService.searchSongs(EMPTY_RESULT_SEARCH_WORD);
+
+        // then
+        assertThat(responses).isEmpty();
+    }
+
+    @DisplayName("XML 응답에 가수가 없으면 가수의 값으로 빈 문자열을 리턴한다.")
+    @Test
+    void searchResultReturnEmptySinger() {
+        // given
+        mockServer.enqueue(new MockResponse()
+            .setResponseCode(HttpStatus.OK.value())
+            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_XML)
+            .addHeader(HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8)
+            .setBody(EMPTY_SINGER_SEARCH_RESULT)
+        );
+
+        final UnregisteredSongSearchResponse expectedResponse = new UnregisteredSongSearchResponse(
+            "흔들리는 꽃들 속에서 네 샴푸향이 느껴진거야",
+            "",
+            "http://i.maniadb.com/images/album/777/777829_1_f.jpg"
+        );
+
+        // when
+        final List<UnregisteredSongSearchResponse> responses =
+            maniaDBSearchService.searchSongs(SEARCH_WORD);
+
+        // then
+        assertAll(
+            () -> assertThat(responses).hasSize(1),
+            () -> assertThat(responses.get(0)).usingRecursiveComparison()
+                .isEqualTo(expectedResponse)
+        );
+    }
+
+    @DisplayName("XML 응답을 파싱한 결과값이 null 이면 예외가 발생한다.")
+    @Test
+    void nullResultThrowException() {
+        // given
+        mockServer.enqueue(new MockResponse()
+            .setResponseCode(HttpStatus.OK.value())
+            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_XML)
+            .addHeader(HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8)
+            .setBody(EMPTY_STRING)
+        );
+
+        // when
+        // then
+        assertThatThrownBy(() -> maniaDBSearchService.searchSongs(SEARCH_WORD))
+            .isInstanceOf(EmptyResultException.class);
+    }
+
+    @DisplayName("ManiaDB로 보내는 요청이 잘못된 경우, 예외가 발생한다.")
+    @Test
+    void wrongRequestThrowException() {
+        // given
+        mockServer.enqueue(new MockResponse()
+            .setResponseCode(HttpStatus.BAD_REQUEST.value())
+            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_XML)
+            .addHeader(HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8)
+        );
+
+        // when
+        // then
+        assertThatThrownBy(() -> maniaDBSearchService.searchSongs(SEARCH_WORD))
+            .isInstanceOf(UnregisteredSongException.ManiaDBClientException.class);
+    }
+
+    @DisplayName("ManiaDB API 서버에서 예외가 발생한 경우, 예외가 발생한다.")
+    @Test
+    void maniaDBServerExceptionThrowException() {
+        // given
+        mockServer.enqueue(new MockResponse()
+            .setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
+            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_XML)
+            .addHeader(HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8)
+        );
+
+        // when
+        // then
+        assertThatThrownBy(() -> maniaDBSearchService.searchSongs(SEARCH_WORD))
+            .isInstanceOf(UnregisteredSongException.ManiaDBServerException.class);
+    }
+}

--- a/backend/src/test/java/shook/shook/song/ui/ManiaDBApiControllerTest.java
+++ b/backend/src/test/java/shook/shook/song/ui/ManiaDBApiControllerTest.java
@@ -1,0 +1,58 @@
+package shook.shook.song.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import io.restassured.RestAssured;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import shook.shook.song.application.dto.UnregisteredSongSearchResponse;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class ManiaDBApiControllerTest {
+
+    @LocalServerPort
+    public int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("내부 DB에 등록되지 않은 노래를 검색할 때 200 상태코드, 노래의 이름과 가수, 앨범 커버를 담은 응답을 반환한다.")
+    @Test
+    void registerPart_unique() {
+        //given
+        final String keyword = "흔들리는꽃들속에서네샴푸향이느껴진거야";
+        final UnregisteredSongSearchResponse expectedFirstResponse = new UnregisteredSongSearchResponse(
+            "흔들리는 꽃들 속에서 네 샴푸향이 느껴진거야",
+            "피아노 가이",
+            "http://i.maniadb.com/images/album/908/908953_1_f.jpg"
+        );
+
+        //when
+        final UnregisteredSongSearchResponse[] songResponses = RestAssured.given().log().all()
+            .when().log().all()
+            .get("/songs/unregistered/search?keyword=" + keyword)
+            .then().log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract().body().as(UnregisteredSongSearchResponse[].class);
+
+        final List<UnregisteredSongSearchResponse> responses = Arrays.stream(
+            songResponses).toList();
+
+        //then
+        assertAll(
+            () -> assertThat(responses).hasSize(19),
+            () -> assertThat(responses.get(0)).usingRecursiveComparison()
+                .isEqualTo(expectedFirstResponse)
+        );
+    }
+}


### PR DESCRIPTION
## 📝작업 내용

ManiaDB API 를 사용하여 등록되지 않은 노래를 검색하는 기능을 구현했습니다.

## 💬리뷰 참고사항

`WebClient` 를 사용하여 외부 API 와 통신하는 로직을 구현했습니다.

ManiaDBController, ManiaDBService 위치를 song 하위에 패키지 없이 두었는데, 위치가 괜찮은지 궁금합니다.

### WebClient를 사용하는 것

`RestTemplate`, `Feign` 같은 다른 대체 라이브러리 대신 `WebClient`를 사용하게 된 이유에 대한 글은 따로 정리한 후 올리겠습니다.

현재 코드 상에서 ManiaDB로 요청을 보내는 메서드는 non-blocking으로 동작하지 않고, blocking으로 동작하고 있습니다.

### 테스트 주의 사항

테스트 중, 통합 테스트가 있는데 그 부분은 ManiaDB 상태에 따라서 될 때도 있고 안 될 때도 있습니다.. 양해 부탁드립니다.

주로 한글로 검색어를 적었을 때 예외가 발생하며, 여러 번 요청을 보내는 경우 ManiaDB가 뻗을 때도 있습니다. 유의하세요.

## #️⃣연관된 이슈

closes #127 


