### PR TITLE
Feat/#154 윈도우 환경변수 주입 오류 해결

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "description": "S-HOOK-frontend",
   "scripts": {
-    "start": "NODE_ENV=development webpack serve --config webpack.dev.js --progress",
-    "build": "NODE_ENV=production webpack --config webpack.prod.js --progress",
+    "start": "webpack serve --config webpack.dev.js --progress",
+    "build": "webpack --config webpack.prod.js --progress",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "lint": "eslint src",

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -1,16 +1,5 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const webpack = require('webpack');
-const dotenv = require('dotenv');
-
-let envPath;
-if (process.NODE_ENV === 'production') {
-  envPath = '.env/.env.production';
-} else {
-  envPath = '.env/.env.development';
-}
-
-dotenv.config({ path: envPath });
 
 module.exports = {
   entry: './src/index.tsx',
@@ -28,9 +17,6 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: './public/index.html',
-    }),
-    new webpack.DefinePlugin({
-      'process.env': JSON.stringify(process.env),
     }),
   ],
   resolve: {

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -1,6 +1,10 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+const webpack = require('webpack');
+const dotenv = require('dotenv');
+
+dotenv.config({ path: '.env/.env.development' });
 
 module.exports = merge(common, {
   mode: 'development',
@@ -8,7 +12,6 @@ module.exports = merge(common, {
     historyApiFallback: true,
     open: true,
   },
-
   module: {
     rules: [
       {
@@ -26,6 +29,10 @@ module.exports = merge(common, {
       },
     ],
   },
-
-  plugins: [new ReactRefreshWebpackPlugin({ overlay: false })],
+  plugins: [
+    new ReactRefreshWebpackPlugin({ overlay: false }),
+    new webpack.DefinePlugin({
+      'process.env': JSON.stringify(process.env),
+    }),
+  ],
 });

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -1,6 +1,10 @@
 const path = require('path');
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common');
+const webpack = require('webpack');
+const dotenv = require('dotenv');
+
+dotenv.config({ path: '.env/.env.production' });
 
 module.exports = merge(common, {
   mode: 'production',
@@ -18,4 +22,9 @@ module.exports = merge(common, {
       },
     ],
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': JSON.stringify(process.env),
+    }),
+  ],
 });


### PR DESCRIPTION
## 📝작업 내용

**cross-env 패키지 설치 없이도** 해결할 수 있는 방안이 있어 **아래와 같이 해결했습니다.**

1. script에서 주입하던 **NODE_ENV 환경변수 삭제**
2. webpack.common.js 파일에서 분기로 처리하던 dotenv path 관련 로직 `삭제` 및 `각 환경 별 설정파일로 이동`


## 각 환경 별 동작 확인 👌 
 
- dev 환경 확인
![dev 확인](https://github.com/woowacourse-teams/2023-shook/assets/77152650/ec7beae2-d6b9-4221-8526-2164964c2b9e)

- prod 환경 확인
![prod 확인](https://github.com/woowacourse-teams/2023-shook/assets/77152650/4f907a3f-4286-42d6-885e-0cac0918494c)


## 💬리뷰 참고사항

프로젝트 내부에서 사용할 각 환경별 변수를 의논하여 정하면 될듯합니다.
현재는 `BASE_URL` 만 사용되고 있긴 합니다~

## #️⃣연관된 이슈

close #154 
