### PR TITLE
REFACTOR/#283 토큰을 생성하는 방식 수정

### DIFF
--- a/backend/src/main/java/shook/shook/auth/application/AuthService.java
+++ b/backend/src/main/java/shook/shook/auth/application/AuthService.java
@@ -10,6 +10,7 @@ import shook.shook.auth.application.dto.TokenReissueResponse;
 import shook.shook.member.application.MemberService;
 import shook.shook.member.domain.Email;
 import shook.shook.member.domain.Member;
+import shook.shook.member.domain.Nickname;
 
 @RequiredArgsConstructor
 @Service
@@ -30,17 +31,19 @@ public class AuthService {
             .orElseGet(() -> memberService.register(userEmail));
 
         final long memberId = member.getId();
-        final String accessToken = tokenProvider.createAccessToken(memberId);
-        final String refreshToken = tokenProvider.createRefreshToken(memberId);
+        final String nickname = member.getNickname();
+        final String accessToken = tokenProvider.createAccessToken(memberId, nickname);
+        final String refreshToken = tokenProvider.createRefreshToken(memberId, nickname);
         return new TokenInfo(accessToken, refreshToken);
     }
 
     public TokenReissueResponse reissueToken(final String refreshToken) {
         final Claims claims = tokenProvider.parseClaims(refreshToken);
         final Long memberId = claims.get("memberId", Long.class);
-        memberService.findById(memberId);
+        final String nickname = claims.get("nickname", String.class);
+        memberService.findByIdAndNickname(memberId, new Nickname(nickname));
 
-        final String accessToken = tokenProvider.createAccessToken(memberId);
+        final String accessToken = tokenProvider.createAccessToken(memberId, nickname);
         return new TokenReissueResponse(accessToken);
     }
 }

--- a/backend/src/main/java/shook/shook/auth/application/TokenProvider.java
+++ b/backend/src/main/java/shook/shook/auth/application/TokenProvider.java
@@ -36,17 +36,18 @@ public class TokenProvider {
         return Keys.hmacShaKeyFor(encodedSecretCode.getBytes());
     }
 
-    public String createAccessToken(final long memberId) {
-        return createToken(memberId, accessTokenValidTime);
+    public String createAccessToken(final long memberId, final String nickname) {
+        return createToken(memberId, nickname, accessTokenValidTime);
     }
 
-    public String createRefreshToken(final long memberId) {
-        return createToken(memberId, refreshTokenValidTime);
+    public String createRefreshToken(final long memberId, final String nickname) {
+        return createToken(memberId, nickname, refreshTokenValidTime);
     }
 
-    private String createToken(final long memberId, final long validTime) {
+    private String createToken(final long memberId, final String nickname, final long validTime) {
         final Claims claims = Jwts.claims().setSubject("user");
         claims.put("memberId", memberId);
+        claims.put("nickname", nickname);
         final Date now = new Date();
         return Jwts.builder()
             .setClaims(claims)

--- a/backend/src/main/java/shook/shook/auth/ui/interceptor/TokenInterceptor.java
+++ b/backend/src/main/java/shook/shook/auth/ui/interceptor/TokenInterceptor.java
@@ -9,6 +9,7 @@ import shook.shook.auth.application.TokenProvider;
 import shook.shook.auth.exception.AuthorizationException;
 import shook.shook.auth.ui.AuthContext;
 import shook.shook.member.application.MemberService;
+import shook.shook.member.domain.Nickname;
 
 @Component
 public class TokenInterceptor implements HandlerInterceptor {
@@ -37,7 +38,8 @@ public class TokenInterceptor implements HandlerInterceptor {
             .orElseThrow(AuthorizationException.AccessTokenNotFoundException::new);
         final Claims claims = tokenProvider.parseClaims(token);
         final Long memberId = claims.get("memberId", Long.class);
-        memberService.findById(memberId);
+        final String nickname = claims.get("nickname", String.class);
+        memberService.findByIdAndNickname(memberId, new Nickname(nickname));
 
         authContext.setAuthenticatedMember(memberId);
 

--- a/backend/src/main/java/shook/shook/member/application/MemberService.java
+++ b/backend/src/main/java/shook/shook/member/application/MemberService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shook.shook.member.domain.Email;
 import shook.shook.member.domain.Member;
+import shook.shook.member.domain.Nickname;
 import shook.shook.member.domain.repository.MemberRepository;
 import shook.shook.member.exception.MemberException;
 import shook.shook.member.exception.MemberException.MemberNotExistException;
@@ -15,6 +16,9 @@ import shook.shook.member.exception.MemberException.MemberNotExistException;
 @Service
 public class MemberService {
 
+    private static final String EMAIL_SPILT_DELIMITER = "@";
+    private static final int NICKNAME_INDEX = 0;
+
     private final MemberRepository memberRepository;
 
     @Transactional
@@ -23,12 +27,18 @@ public class MemberService {
             .ifPresent(member -> {
                 throw new MemberException.ExistMemberException();
             });
-        final Member newMember = new Member(email, email);
+        final String nickname = email.split(EMAIL_SPILT_DELIMITER)[NICKNAME_INDEX];
+        final Member newMember = new Member(email, nickname);
         return memberRepository.save(newMember);
     }
 
     public Optional<Member> findByEmail(final Email email) {
         return memberRepository.findByEmail(email);
+    }
+
+    public Member findByIdAndNickname(final Long id, final Nickname nickname) {
+        return memberRepository.findByIdAndNickname(id, nickname)
+            .orElseThrow(MemberException.MemberNotExistException::new);
     }
 
     public Member findById(final Long id) {

--- a/backend/src/main/java/shook/shook/member/domain/repository/MemberRepository.java
+++ b/backend/src/main/java/shook/shook/member/domain/repository/MemberRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import shook.shook.member.domain.Email;
 import shook.shook.member.domain.Member;
+import shook.shook.member.domain.Nickname;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(final Email email);
+
+    Optional<Member> findByIdAndNickname(final Long id, final Nickname nickname);
 }

--- a/backend/src/test/java/shook/shook/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/shook/shook/auth/application/AuthServiceTest.java
@@ -80,13 +80,17 @@ class AuthServiceTest {
     @Test
     void success_reissue() {
         //given
-        final String refreshToken = tokenProvider.createRefreshToken(savedMember.getId());
+        final String refreshToken = tokenProvider.createRefreshToken(
+            savedMember.getId(),
+            savedMember.getNickname());
 
         //when
         final TokenReissueResponse result = authService.reissueToken(refreshToken);
 
         //then
-        final String accessToken = tokenProvider.createAccessToken(savedMember.getId());
+        final String accessToken = tokenProvider.createAccessToken(
+            savedMember.getId(),
+            savedMember.getNickname());
 
         assertThat(result.getAccessToken()).isEqualTo(accessToken);
     }
@@ -100,7 +104,9 @@ class AuthServiceTest {
             100L,
             "asdzzxcwetg2adfvssd3xZcZXCZvzx");
 
-        final String refreshToken = inValidTokenProvider.createRefreshToken(savedMember.getId());
+        final String refreshToken = inValidTokenProvider.createRefreshToken(
+            savedMember.getId(),
+            savedMember.getNickname());
 
         //when
         //then
@@ -117,7 +123,9 @@ class AuthServiceTest {
             0,
             "asdfsdsvsdf2esvsdvsdvs23");
 
-        final String refreshToken = inValidTokenProvider.createRefreshToken(savedMember.getId());
+        final String refreshToken = inValidTokenProvider.createRefreshToken(
+            savedMember.getId(),
+            savedMember.getNickname());
 
         //when
         //then

--- a/backend/src/test/java/shook/shook/auth/application/TokenProviderTest.java
+++ b/backend/src/test/java/shook/shook/auth/application/TokenProviderTest.java
@@ -28,11 +28,12 @@ class TokenProviderTest {
     void createAccessToken() {
         //given
         //when
-        final String accessToken = tokenProvider.createAccessToken(1L);
+        final String accessToken = tokenProvider.createAccessToken(1L, "shook");
         final Claims result = tokenProvider.parseClaims(accessToken);
 
         //then
         assertThat(result.get("memberId")).isEqualTo(1);
+        assertThat(result.get("nickname")).isEqualTo("shook");
         assertThat(result.getExpiration().getTime() - result.getIssuedAt().getTime())
             .isEqualTo(ACCESS_TOKEN_VALID_TIME);
     }
@@ -42,11 +43,12 @@ class TokenProviderTest {
     void createRefreshToken() {
         //given
         // when
-        final String refreshToken = tokenProvider.createRefreshToken(1L);
+        final String refreshToken = tokenProvider.createRefreshToken(1L, "shook");
         final Claims result = tokenProvider.parseClaims(refreshToken);
 
         // then
         assertThat(result.get("memberId")).isEqualTo(1);
+        assertThat(result.get("nickname")).isEqualTo("shook");
         assertThat(result.getExpiration().getTime() - result.getIssuedAt().getTime())
             .isEqualTo(REFRESH_TOKEN_VALID_TIME);
     }
@@ -68,7 +70,7 @@ class TokenProviderTest {
     void parsing_fail_expired_token() {
         // given
         tokenProvider = new TokenProvider(0, 0, SECRET_CODE);
-        final String expiredToken = tokenProvider.createAccessToken(1L);
+        final String expiredToken = tokenProvider.createAccessToken(1L, "shook");
 
         //when
         //then

--- a/backend/src/test/java/shook/shook/auth/ui/TokenControllerTest.java
+++ b/backend/src/test/java/shook/shook/auth/ui/TokenControllerTest.java
@@ -46,7 +46,9 @@ class TokenControllerTest {
     @Test
     void success_reissue_accessToken() {
         //given
-        final String refreshToken = tokenProvider.createRefreshToken(savedMember.getId());
+        final String refreshToken = tokenProvider.createRefreshToken(
+            savedMember.getId(),
+            savedMember.getNickname());
 
         //when
         final TokenReissueResponse response = RestAssured.given().log().all()
@@ -56,7 +58,9 @@ class TokenControllerTest {
             .extract().body().as(TokenReissueResponse.class);
 
         //then
-        final String accessToken = tokenProvider.createAccessToken(savedMember.getId());
+        final String accessToken = tokenProvider.createAccessToken(
+            savedMember.getId(),
+            savedMember.getNickname());
 
         assertThat(response.getAccessToken()).isEqualTo(accessToken);
     }

--- a/backend/src/test/java/shook/shook/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/shook/shook/member/application/MemberServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import shook.shook.member.domain.Email;
 import shook.shook.member.domain.Member;
+import shook.shook.member.domain.Nickname;
 import shook.shook.member.domain.repository.MemberRepository;
 import shook.shook.member.exception.MemberException;
 import shook.shook.member.exception.MemberException.MemberNotExistException;
@@ -39,8 +40,10 @@ class MemberServiceTest extends UsingJpaTest {
         final Member result = memberService.register(email);
 
         //then
+        final String nickname = email.split("@")[0];
+
         assertThat(result.getEmail()).isEqualTo(email);
-        assertThat(result.getNickname()).isEqualTo(email);
+        assertThat(result.getNickname()).isEqualTo(nickname);
     }
 
     @DisplayName("중복된 이메일로 회원을 등록되는 경우 예외를 던진다.")
@@ -82,7 +85,7 @@ class MemberServiceTest extends UsingJpaTest {
         assertThat(result.getNickname()).isEqualTo(savedMember.getNickname());
     }
 
-    @DisplayName("회원을 id로 조회할 때 존재하지 않으면 예외를 던진다..")
+    @DisplayName("회원을 id로 조회할 때 존재하지 않으면 예외를 던진다.")
     @Test
     void fail_findById() {
         //given
@@ -90,5 +93,54 @@ class MemberServiceTest extends UsingJpaTest {
         //then
         assertThatThrownBy(() -> memberService.findById(Long.MAX_VALUE))
             .isInstanceOf(MemberNotExistException.class);
+    }
+
+    @DisplayName("회원을 id와 nickname으로 조회한다.")
+    @Test
+    void success_findByIdAndNickname() {
+        //given
+        //when
+        final Member result = memberService.findByIdAndNickname(
+            savedMember.getId(),
+            new Nickname(savedMember.getNickname()));
+
+        //then
+        assertThat(result).usingRecursiveComparison().isEqualTo(savedMember);
+    }
+
+    @DisplayName("회원을 id와 nickname으로 조회할 때 회원의 닉네임이 잘못되면 예외를 던진다.")
+    @Test
+    void fail_findByIdAndNickname_wrong_nickname() {
+        //given
+        //when
+        //then
+        assertThatThrownBy(
+            () -> memberService.findByIdAndNickname(savedMember.getId(),
+                new Nickname(savedMember.getNickname() + "none")))
+            .isInstanceOf(MemberException.MemberNotExistException.class);
+    }
+
+    @DisplayName("회원을 id와 nickname으로 조회할 때 회원의 id가 잘못되면 예외를 던진다.")
+    @Test
+    void fail_findByIdAndNickname_wrong_memberId() {
+        //given
+        //when
+        //then
+        assertThatThrownBy(
+            () -> memberService.findByIdAndNickname(savedMember.getId() + 1,
+                new Nickname(savedMember.getNickname())))
+            .isInstanceOf(MemberException.MemberNotExistException.class);
+    }
+
+    @DisplayName("회원을 id와 nickname으로 조회할 때 회원의 id와 nickname 모두 잘못되면 예외를 던진다.")
+    @Test
+    void fail_findByIdAndNickname_wrong_memberId_and_nickname() {
+        //given
+        //when
+        //then
+        assertThatThrownBy(
+            () -> memberService.findByIdAndNickname(savedMember.getId() + 1,
+                new Nickname(savedMember.getNickname() + "none")))
+            .isInstanceOf(MemberException.MemberNotExistException.class);
     }
 }

--- a/backend/src/test/java/shook/shook/song/ui/KillingPartLikeControllerTest.java
+++ b/backend/src/test/java/shook/shook/song/ui/KillingPartLikeControllerTest.java
@@ -22,6 +22,7 @@ class KillingPartLikeControllerTest {
     private static final long SAVED_KILLING_PART_ID = 1L;
     private static final long SAVED_SONG_ID = 1L;
     private static final long SAVED_MEMBER_ID = 1L;
+    private static final String SAVED_MEMBER_NICKNAME = "nickname";
     private static final String TOKEN_PREFIX = "Bearer ";
 
     @LocalServerPort
@@ -40,7 +41,9 @@ class KillingPartLikeControllerTest {
     void createLikeOnKillingPart() {
         // given
         final KillingPartLikeRequest request = new KillingPartLikeRequest(true);
-        final String accessToken = tokenProvider.createAccessToken(SAVED_MEMBER_ID);
+        final String accessToken = tokenProvider.createAccessToken(
+            SAVED_MEMBER_ID,
+            SAVED_MEMBER_NICKNAME);
 
         // when, then
         RestAssured.given().log().all()
@@ -59,7 +62,9 @@ class KillingPartLikeControllerTest {
     void deleteLikeOnKillingPart() {
         // given
         final KillingPartLikeRequest request = new KillingPartLikeRequest(false);
-        final String accessToken = tokenProvider.createAccessToken(SAVED_MEMBER_ID);
+        final String accessToken = tokenProvider.createAccessToken(
+            SAVED_MEMBER_ID,
+            SAVED_MEMBER_NICKNAME);
 
         // when, then
         RestAssured.given().log().all()


### PR DESCRIPTION
## 📝작업 내용
토큰을 생성할 때 nickname추가하여 생성하도록 수정하였습니다.

## 💬리뷰 참고사항
- memberserivce의 register에서 email에서 nickname을 파싱하는 과정이 포함되어 있는데 이는 아직 소셜 로그인만 존재하여 따로 분리하지 않았습니다. 나중에서 다른 소셜 로그인이나 일반 로그인이 생기면 그 때 분리하면 좋을 것 같습니다.

## #️⃣연관된 이슈
- close #283 


