### PR TITLE
Feat/#282: KillingPartComment 등록, 조회 API 사용자 추가

### DIFF
--- a/backend/src/main/java/shook/shook/member/application/MemberService.java
+++ b/backend/src/main/java/shook/shook/member/application/MemberService.java
@@ -9,7 +9,6 @@ import shook.shook.member.domain.Member;
 import shook.shook.member.domain.Nickname;
 import shook.shook.member.domain.repository.MemberRepository;
 import shook.shook.member.exception.MemberException;
-import shook.shook.member.exception.MemberException.MemberNotExistException;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -43,6 +42,6 @@ public class MemberService {
 
     public Member findById(final Long id) {
         return memberRepository.findById(id)
-            .orElseThrow(MemberNotExistException::new);
+            .orElseThrow(MemberException.MemberNotExistException::new);
     }
 }

--- a/backend/src/main/java/shook/shook/song/application/killingpart/KillingPartCommentService.java
+++ b/backend/src/main/java/shook/shook/song/application/killingpart/KillingPartCommentService.java
@@ -4,6 +4,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import shook.shook.member.domain.Member;
+import shook.shook.member.domain.repository.MemberRepository;
+import shook.shook.member.exception.MemberException.MemberNotExistException;
 import shook.shook.song.application.killingpart.dto.KillingPartCommentRegisterRequest;
 import shook.shook.song.application.killingpart.dto.KillingPartCommentResponse;
 import shook.shook.song.domain.killingpart.KillingPart;
@@ -19,14 +22,21 @@ public class KillingPartCommentService {
 
     private final KillingPartRepository killingPartRepository;
     private final KillingPartCommentRepository killingPartCommentRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
-    public void register(final long partId, final KillingPartCommentRegisterRequest request) {
+    public void register(final long partId, final KillingPartCommentRegisterRequest request,
+        final Long memberId) {
+        final Member member = memberRepository.findById(memberId)
+            .orElseThrow(MemberNotExistException::new);
+
         final KillingPart killingPart = killingPartRepository.findById(partId)
             .orElseThrow(KillingPartException.PartNotExistException::new);
+
         final KillingPartComment killingPartComment = KillingPartComment.forSave(
             killingPart,
-            request.getContent()
+            request.getContent(),
+            member
         );
 
         killingPart.addComment(killingPartComment);

--- a/backend/src/main/java/shook/shook/song/application/killingpart/KillingPartLikeService.java
+++ b/backend/src/main/java/shook/shook/song/application/killingpart/KillingPartLikeService.java
@@ -29,7 +29,7 @@ public class KillingPartLikeService {
         final KillingPartLikeRequest request
     ) {
         final Member member = memberRepository.findById(memberId)
-            .orElseThrow(MemberException::new);
+            .orElseThrow(MemberException.MemberNotExistException::new);
 
         final KillingPart killingPart = killingPartRepository.findById(killingPartId)
             .orElseThrow(KillingPartException.PartNotExistException::new);

--- a/backend/src/main/java/shook/shook/song/application/killingpart/dto/KillingPartCommentResponse.java
+++ b/backend/src/main/java/shook/shook/song/application/killingpart/dto/KillingPartCommentResponse.java
@@ -13,12 +13,14 @@ public class KillingPartCommentResponse {
 
     private final Long id;
     private final String content;
+    private final String writerNickname;
     private final LocalDateTime createdAt;
 
     public static KillingPartCommentResponse from(final KillingPartComment killingPartComment) {
         return new KillingPartCommentResponse(
             killingPartComment.getId(),
             killingPartComment.getContent(),
+            killingPartComment.getWriterNickname(),
             killingPartComment.getCreatedAt()
         );
     }

--- a/backend/src/main/java/shook/shook/song/domain/killingpart/KillingPartComment.java
+++ b/backend/src/main/java/shook/shook/song/domain/killingpart/KillingPartComment.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import shook.shook.member.domain.Member;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -37,6 +38,11 @@ public class KillingPartComment {
     @Getter(AccessLevel.NONE)
     private KillingPart killingPart;
 
+    @ManyToOne
+    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "none"), updatable = false, nullable = false)
+    @Getter(AccessLevel.NONE)
+    private Member member;
+
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
 
@@ -45,26 +51,41 @@ public class KillingPartComment {
         createdAt = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS);
     }
 
-    private KillingPartComment(final Long id, final KillingPart killingPart, final String content) {
+    private KillingPartComment(
+        final Long id,
+        final KillingPart killingPart,
+        final String content,
+        final Member member
+    ) {
         this.id = id;
         this.killingPart = killingPart;
         this.content = new KillingPartCommentContent(content);
+        this.member = member;
     }
 
     public static KillingPartComment saved(
         final Long id,
         final KillingPart part,
-        final String content
+        final String content,
+        final Member member
     ) {
-        return new KillingPartComment(id, part, content);
+        return new KillingPartComment(id, part, content, member);
     }
 
-    public static KillingPartComment forSave(final KillingPart part, final String content) {
-        return new KillingPartComment(null, part, content);
+    public static KillingPartComment forSave(
+        final KillingPart part,
+        final String content,
+        final Member member
+    ) {
+        return new KillingPartComment(null, part, content, member);
     }
 
     public boolean isBelongToOtherKillingPart(final KillingPart killingPart) {
         return !this.killingPart.equals(killingPart);
+    }
+
+    public String getWriterNickname() {
+        return member.getNickname();
     }
 
     public String getContent() {

--- a/backend/src/main/java/shook/shook/song/ui/KillingPartCommentController.java
+++ b/backend/src/main/java/shook/shook/song/ui/KillingPartCommentController.java
@@ -1,5 +1,6 @@
 package shook.shook.song.ui;
 
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -10,6 +11,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import shook.shook.auth.ui.argumentresolver.Authenticated;
+import shook.shook.auth.ui.argumentresolver.MemberInfo;
 import shook.shook.song.application.killingpart.KillingPartCommentService;
 import shook.shook.song.application.killingpart.dto.KillingPartCommentRegisterRequest;
 import shook.shook.song.application.killingpart.dto.KillingPartCommentResponse;
@@ -24,10 +27,10 @@ public class KillingPartCommentController {
     @PostMapping
     public ResponseEntity<Void> registerKillingPartComment(
         @PathVariable(name = "killing_part_id") final Long killingPartId,
-        @RequestBody final KillingPartCommentRegisterRequest request
-        // TODO: 2023/08/15 memberInfo 추가하기 
+        @Valid @RequestBody final KillingPartCommentRegisterRequest request,
+        @Authenticated final MemberInfo memberInfo
     ) {
-        killingPartCommentService.register(killingPartId, request);
+        killingPartCommentService.register(killingPartId, request, memberInfo.getMemberId());
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/backend/src/main/resources/dev/schema.sql
+++ b/backend/src/main/resources/dev/schema.sql
@@ -24,6 +24,7 @@ create table if not exists killing_part
     start_second integer      not null,
     length       varchar(255) not null check (length in ('SHORT', 'STANDARD', 'LONG')),
     song_id      bigint       not null,
+    like_count   integer      not null,
     created_at   timestamp(6) not null,
     primary key (id)
 );
@@ -43,6 +44,7 @@ create table if not exists killing_part_comment
 (
     id              bigint auto_increment,
     killing_part_id bigint       not null,
+    member_id       bigint       not null,
     content         varchar(200) not null,
     created_at      timestamp(6) not null,
     primary key (id)
@@ -83,6 +85,3 @@ create table if not exists member
     nickname varchar(100) not null,
     primary key (id)
 );
-
-alter table killing_part
-    add column like_count integer not null;

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -77,3 +77,4 @@ create table if not exists member
 );
 
 alter table killing_part add column like_count integer not null;
+alter table killing_part_comment add column member_id bigint not null;

--- a/backend/src/test/java/shook/shook/song/application/killingpart/KillingPartCommentServiceTest.java
+++ b/backend/src/test/java/shook/shook/song/application/killingpart/KillingPartCommentServiceTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
+import shook.shook.member.domain.Member;
+import shook.shook.member.domain.repository.MemberRepository;
 import shook.shook.song.application.killingpart.dto.KillingPartCommentRegisterRequest;
 import shook.shook.song.application.killingpart.dto.KillingPartCommentResponse;
 import shook.shook.song.domain.killingpart.KillingPart;
@@ -22,6 +24,8 @@ import shook.shook.support.UsingJpaTest;
 class KillingPartCommentServiceTest extends UsingJpaTest {
 
     private static final long UNSAVED_PART_ID = Long.MAX_VALUE;
+    private static final long MEMBER_ID = 1L;
+    private static Member MEMBER;
     private static KillingPart SAVED_PART;
 
     @Autowired
@@ -30,13 +34,17 @@ class KillingPartCommentServiceTest extends UsingJpaTest {
     @Autowired
     private KillingPartCommentRepository killingPartCommentRepository;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     private KillingPartCommentService killingPartCommentService;
 
     @BeforeEach
     void setUp() {
         SAVED_PART = killingPartRepository.findById(1L).get();
+        MEMBER = memberRepository.findById(MEMBER_ID).get();
         killingPartCommentService = new KillingPartCommentService(killingPartRepository,
-            killingPartCommentRepository);
+            killingPartCommentRepository, memberRepository);
     }
 
     @DisplayName("킬링파트에 댓글을 등록한다.")
@@ -47,7 +55,7 @@ class KillingPartCommentServiceTest extends UsingJpaTest {
             "댓글 내용");
 
         //when
-        killingPartCommentService.register(SAVED_PART.getId(), request);
+        killingPartCommentService.register(SAVED_PART.getId(), request, MEMBER_ID);
         saveAndClearEntityManager();
 
         //then
@@ -64,7 +72,8 @@ class KillingPartCommentServiceTest extends UsingJpaTest {
             "댓글 내용");
 
         // when, then
-        assertThatThrownBy(() -> killingPartCommentService.register(UNSAVED_PART_ID, request))
+        assertThatThrownBy(
+            () -> killingPartCommentService.register(UNSAVED_PART_ID, request, MEMBER_ID))
             .isInstanceOf(KillingPartException.PartNotExistException.class);
     }
 
@@ -73,9 +82,9 @@ class KillingPartCommentServiceTest extends UsingJpaTest {
     void findKillingPartComments() {
         //given
         final KillingPartComment early = killingPartCommentRepository.save(
-            KillingPartComment.forSave(SAVED_PART, "1"));
+            KillingPartComment.forSave(SAVED_PART, "1", MEMBER));
         final KillingPartComment late = killingPartCommentRepository.save(
-            KillingPartComment.forSave(SAVED_PART, "2"));
+            KillingPartComment.forSave(SAVED_PART, "2", MEMBER));
 
         //when
         saveAndClearEntityManager();

--- a/backend/src/test/java/shook/shook/song/domain/killingpart/KillingPartCommentTest.java
+++ b/backend/src/test/java/shook/shook/song/domain/killingpart/KillingPartCommentTest.java
@@ -5,12 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import shook.shook.member.domain.Member;
 import shook.shook.part.domain.PartLength;
 import shook.shook.song.domain.Song;
 
 class KillingPartCommentTest {
 
     private static final Song EMPTY_SONG = null;
+    private static final Member MEMBER = new Member("email@naver.com", "nickname");
     private static final KillingPart FIRST_KILLING_PART =
         KillingPart.saved(1L, 4, PartLength.SHORT, EMPTY_SONG);
     private static final KillingPart SECOND_KILLING_PART =
@@ -22,7 +24,7 @@ class KillingPartCommentTest {
         //given
         //when
         //then
-        assertDoesNotThrow(() -> KillingPartComment.forSave(FIRST_KILLING_PART, "댓글 내용"));
+        assertDoesNotThrow(() -> KillingPartComment.forSave(FIRST_KILLING_PART, "댓글 내용", MEMBER));
     }
 
     @DisplayName("이미 작성된 댓글을 생성한다.")
@@ -31,7 +33,7 @@ class KillingPartCommentTest {
         //given
         //when
         //then
-        assertDoesNotThrow(() -> KillingPartComment.saved(1L, FIRST_KILLING_PART, "댓글 내용"));
+        assertDoesNotThrow(() -> KillingPartComment.saved(1L, FIRST_KILLING_PART, "댓글 내용", MEMBER));
     }
 
     @DisplayName("댓글의 내용을 반환한다.")
@@ -39,7 +41,7 @@ class KillingPartCommentTest {
     void getContent() {
         //given
         final KillingPartComment killingPartComment = KillingPartComment.forSave(FIRST_KILLING_PART,
-            "댓글 내용");
+            "댓글 내용", MEMBER);
 
         //when
         final String content = killingPartComment.getContent();
@@ -53,7 +55,7 @@ class KillingPartCommentTest {
     void isBelongToOtherPart_samePart() {
         //given
         final KillingPartComment killingPartComment = KillingPartComment.forSave(FIRST_KILLING_PART,
-            "댓글 내용");
+            "댓글 내용", MEMBER);
 
         //when
         final boolean isBelongTo = killingPartComment.isBelongToOtherKillingPart(
@@ -68,7 +70,7 @@ class KillingPartCommentTest {
     void isBelongToOtherPart_otherPart() {
         //given
         final KillingPartComment partComment = KillingPartComment.forSave(FIRST_KILLING_PART,
-            "댓글 내용");
+            "댓글 내용", MEMBER);
 
         //when
         final boolean isBelongTo = partComment.isBelongToOtherKillingPart(SECOND_KILLING_PART);

--- a/backend/src/test/java/shook/shook/song/domain/killingpart/KillingPartCommentsTest.java
+++ b/backend/src/test/java/shook/shook/song/domain/killingpart/KillingPartCommentsTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import shook.shook.member.domain.Member;
 import shook.shook.part.domain.PartLength;
 import shook.shook.song.domain.Song;
 import shook.shook.song.exception.killingpart.KillingPartCommentException;
@@ -13,6 +14,7 @@ import shook.shook.song.exception.killingpart.KillingPartCommentException;
 class KillingPartCommentsTest {
 
     private static final Song EMPTY_SONG = null;
+    private static final Member MEMBER = new Member("email@naver.com", "nickname");
 
     @DisplayName("새 댓글이 킬링파트에 추가된다.")
     @Test
@@ -23,7 +25,7 @@ class KillingPartCommentsTest {
         final KillingPartComments comments = new KillingPartComments();
 
         //when
-        comments.addComment(KillingPartComment.saved(1L, killingPart, "댓글 내용"));
+        comments.addComment(KillingPartComment.saved(1L, killingPart, "댓글 내용", MEMBER));
 
         //then
         assertThat(comments.getComments()).hasSize(1);
@@ -37,11 +39,12 @@ class KillingPartCommentsTest {
         final KillingPartComments partComments = new KillingPartComments();
 
         //when
-        partComments.addComment(KillingPartComment.saved(1L, killingPart, "댓글 내용"));
+        partComments.addComment(KillingPartComment.saved(1L, killingPart, "댓글 내용", MEMBER));
 
         //then
         assertThatThrownBy(
-            () -> partComments.addComment(KillingPartComment.saved(1L, killingPart, "댓글 내용"))
+            () -> partComments.addComment(
+                KillingPartComment.saved(1L, killingPart, "댓글 내용", MEMBER))
         ).isInstanceOf(KillingPartCommentException.DuplicateCommentExistException.class);
     }
 
@@ -52,8 +55,10 @@ class KillingPartCommentsTest {
         final KillingPart killingPart = KillingPart.saved(1L, 5, PartLength.SHORT, EMPTY_SONG);
         final KillingPartComments comments = new KillingPartComments();
 
-        final KillingPartComment early = KillingPartComment.saved(1L, killingPart, "댓글입니다.");
-        final KillingPartComment late = KillingPartComment.saved(2L, killingPart, "댓글이였습니다.");
+        final KillingPartComment early = KillingPartComment.saved(1L, killingPart, "댓글입니다.",
+            MEMBER);
+        final KillingPartComment late = KillingPartComment.saved(2L, killingPart, "댓글이였습니다.",
+            MEMBER);
 
         comments.addComment(late);
         comments.addComment(early);

--- a/backend/src/test/java/shook/shook/song/domain/killingpart/KillingPartTest.java
+++ b/backend/src/test/java/shook/shook/song/domain/killingpart/KillingPartTest.java
@@ -19,6 +19,7 @@ import shook.shook.song.exception.killingpart.KillingPartLikeException;
 class KillingPartTest {
 
     private static final Song EMPTY_SONG = null;
+    private static final Member MEMBER = new Member("email@naver.com", "nickname");
 
     @DisplayName("Id가 같은 킬링파트는 동등성 비교에 참을 반환한다.")
     @Test
@@ -95,7 +96,7 @@ class KillingPartTest {
             final KillingPart killingPart = KillingPart.saved(1L, 5, PartLength.SHORT, EMPTY_SONG);
 
             //when
-            killingPart.addComment(KillingPartComment.saved(1L, killingPart, "댓글 내용"));
+            killingPart.addComment(KillingPartComment.saved(1L, killingPart, "댓글 내용", MEMBER));
 
             //then
             assertThat(killingPart.getComments()).hasSize(1);
@@ -111,7 +112,8 @@ class KillingPartTest {
             //when
             //then
             assertThatThrownBy(
-                () -> firstPart.addComment(KillingPartComment.saved(2L, secondPart, "댓글 내용")))
+                () -> firstPart.addComment(
+                    KillingPartComment.saved(2L, secondPart, "댓글 내용", MEMBER)))
                 .isInstanceOf(KillingPartCommentException.CommentForOtherPartException.class);
         }
     }

--- a/backend/src/test/java/shook/shook/song/domain/killingpart/repository/KillingPartCommentRepositoryTest.java
+++ b/backend/src/test/java/shook/shook/song/domain/killingpart/repository/KillingPartCommentRepositoryTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
+import shook.shook.member.domain.Member;
+import shook.shook.member.domain.repository.MemberRepository;
 import shook.shook.song.domain.killingpart.KillingPart;
 import shook.shook.song.domain.killingpart.KillingPartComment;
 import shook.shook.support.UsingJpaTest;
@@ -17,6 +19,7 @@ import shook.shook.support.UsingJpaTest;
 class KillingPartCommentRepositoryTest extends UsingJpaTest {
 
     private static KillingPart SAVED_KILLING_PART;
+    private static Member MEMBER;
 
     @Autowired
     private KillingPartRepository killingPartRepository;
@@ -24,9 +27,13 @@ class KillingPartCommentRepositoryTest extends UsingJpaTest {
     @Autowired
     private KillingPartCommentRepository killingPartCommentRepository;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     @BeforeEach
     void setUp() {
         SAVED_KILLING_PART = killingPartRepository.findById(1L).get();
+        MEMBER = memberRepository.findById(1L).get();
     }
 
     @DisplayName("KillingPartComment 를 저장한다.")
@@ -34,7 +41,7 @@ class KillingPartCommentRepositoryTest extends UsingJpaTest {
     void save() {
         //given
         final KillingPartComment partComment = KillingPartComment.forSave
-            (SAVED_KILLING_PART, "댓글 내용");
+            (SAVED_KILLING_PART, "댓글 내용", MEMBER);
 
         //when
         final KillingPartComment savedPartComment = killingPartCommentRepository.save(partComment);
@@ -49,7 +56,7 @@ class KillingPartCommentRepositoryTest extends UsingJpaTest {
     void createdAt() {
         //given
         final KillingPartComment partComment = KillingPartComment.forSave(SAVED_KILLING_PART,
-            "댓글 내용");
+            "댓글 내용", MEMBER);
 
         //when
         final LocalDateTime prev = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS);

--- a/backend/src/test/java/shook/shook/song/ui/KillingPartCommentControllerTest.java
+++ b/backend/src/test/java/shook/shook/song/ui/KillingPartCommentControllerTest.java
@@ -6,15 +6,18 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.jdbc.Sql;
+import shook.shook.auth.application.TokenProvider;
+import shook.shook.member.domain.Member;
+import shook.shook.member.domain.repository.MemberRepository;
 import shook.shook.song.application.killingpart.dto.KillingPartCommentRegisterRequest;
 import shook.shook.song.application.killingpart.dto.KillingPartCommentResponse;
 import shook.shook.song.domain.killingpart.KillingPart;
@@ -28,6 +31,7 @@ class KillingPartCommentControllerTest {
 
     private static final long SAVED_KILLING_PART_ID = 1L;
     private static final long SAVED_SONG_ID = 1L;
+    private static Member MEMBER;
 
     @LocalServerPort
     public int port;
@@ -38,23 +42,31 @@ class KillingPartCommentControllerTest {
     @Autowired
     private KillingPartCommentRepository killingPartCommentRepository;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
+        MEMBER = memberRepository.findById(1L).get();
     }
 
-    // TODO: 2023/08/15 memberInfo 추가하고 테스트 다시 작성하기
-    @Disabled
     @DisplayName("킬링파트에 댓글 등록시 상태코드 201를 반환한다.")
     @Test
     void registerKillingPartComment() {
         // given
         final KillingPartCommentRegisterRequest request = new KillingPartCommentRegisterRequest(
             "댓글 내용");
+        final String accessToken = tokenProvider.createAccessToken(MEMBER.getId(),
+            MEMBER.getNickname());
 
         // when, then
         RestAssured.given().log().all()
             .contentType(ContentType.JSON)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
             .body(request)
             .when().log().all()
             .post("/songs/{songId}/parts/{killingPartId}/comments", SAVED_SONG_ID,
@@ -69,9 +81,9 @@ class KillingPartCommentControllerTest {
         //given
         final KillingPart killingPart = killingPartRepository.findById(SAVED_KILLING_PART_ID).get();
         final KillingPartComment savedComment1 = killingPartCommentRepository.save(
-            KillingPartComment.forSave(killingPart, "댓글 내용"));
+            KillingPartComment.forSave(killingPart, "댓글 내용", MEMBER));
         final KillingPartComment savedComment2 = killingPartCommentRepository.save(
-            KillingPartComment.forSave(killingPart, "2번 댓글"));
+            KillingPartComment.forSave(killingPart, "2번 댓글", MEMBER));
 
         //when
         final List<KillingPartCommentResponse> response = RestAssured.given().log().all()

--- a/backend/src/test/resources/killingpart/initialize_killing_part_song.sql
+++ b/backend/src/test/resources/killingpart/initialize_killing_part_song.sql
@@ -51,6 +51,7 @@ create table if not exists killing_part_comment
     id              bigint auto_increment,
     killing_part_id bigint       not null,
     content         varchar(200) not null,
+    member_id       bigint       not null,
     created_at      timestamp(6) not null,
     primary key (id)
 );

--- a/backend/src/test/resources/song/drop_create_empty_schema.sql
+++ b/backend/src/test/resources/song/drop_create_empty_schema.sql
@@ -43,6 +43,7 @@ create table if not exists killing_part_comment
     id              bigint auto_increment,
     killing_part_id bigint       not null,
     content         varchar(200) not null,
+    member_id       bigint       not null,
     created_at      timestamp(6) not null,
     primary key (id)
     );


### PR DESCRIPTION
## 📝작업 내용

KillingPartComment 등록, 조회 API 사용자 추가
- KillingPartComment 등록 시 accessToken으로 작성자를 함께 저장한다. 
- KillingPartComment 조회 시 작성자 이름을 함께 조회한다.

## 💬리뷰 참고사항

- KillingPartComment 비교 테스트가 터지는데, 베로의 PR에서 #278 수정이 되었다고 합니다. 추후 main에 반영 후, 수정하도록 하겠습니다.

## #️⃣연관된 이슈

closes #282 


