### PR TITLE
Feat/#287 release drafter를 적용한다.

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -9,7 +9,7 @@ categories:
   - title: '🐛 Bug Fixes'
     labels:
       - '🦋 Bug'
-  - title: ' Infrastructure'
+  - title: '🤖 Infrastructure'
     labels:
       - '🤖 InfrA'
       - '🐈‍⬛ Github'
@@ -32,7 +32,7 @@ version-resolver:
       - 'patch'
   default: patch
 template: |
-  ## 🚀 이번 버전에서는 어떤 게 바뀌었을까요?
+  ## 🎉 이번 버전에서는 어떤 게 바뀌었을까요?
 
   $CHANGES
 

--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,40 @@
+name-template: '🚀 v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - '✨ Feat'
+      - '💿 Databas🦷'
+      - '🎨 DesigN'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - '🦋 Bug'
+  - title: ' Infrastructure'
+    labels:
+      - '🤖 InfrA'
+      - '🐈‍⬛ Github'
+  - title: '🧰 Maintenance'
+    label:
+      - '🔨 Refactor'
+      - '⚙️ Settin🐁'
+      - '✍️ Docs'
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## 🚀 이번 버전에서는 어떤 게 바뀌었을까요?
+
+  $CHANGES
+
+  Full Changelog: https://github.com/woowacourse-teams/2023-shook/commits/v$RESOLVED_VERSION
+no-changes-template: '앗! 변경사항이 없어요.😖 '

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

release drafter를 적용하여 다음 release까지 changelog들이 draft로 쌓이도록 적용하였습니다.
github action을 사용하였으며 main에 merge(push)될때 적용됩니다.

https://github.com/release-drafter/release-drafter

## 💬리뷰 참고사항

> 원활한 리뷰를 위해 전달하고 싶은 맥락(특정 파일, 디렉터리 등등)  
> 리뷰어가 특별히 봐주었으면 하는 부분

draft이므로 우리가 publish 해주어야 합니다.

- 좌측 사진에서 publish할 때 태그를 버저닝 해주어야 합니다.
- 우측 사진에서 기준 커밋을 정합니다.

<img width="301" alt="image" src="https://github.com/woowacourse-teams/2023-shook/assets/87710730/5d409e43-b4e6-4ad7-8a4a-1d5e92514d75">

<img width="298" alt="image" src="https://github.com/woowacourse-teams/2023-shook/assets/87710730/084ae3db-b42f-41d9-a2b6-77f3679aa9ba">

## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성

close #287 

## 📸예시 사진

<img width="899" alt="image" src="https://github.com/woowacourse-teams/2023-shook/assets/87710730/0565f438-6e63-47d2-982a-1122111d8161">
