### PR TITLE
Hotfix/#293 이전 노래 조회 쿼리 수정

### DIFF
--- a/backend/src/main/java/shook/shook/song/application/SongService.java
+++ b/backend/src/main/java/shook/shook/song/application/SongService.java
@@ -1,5 +1,6 @@
 package shook.shook.song.application;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -80,9 +81,12 @@ public class SongService {
     }
 
     private List<Song> findBeforeSongs(final Song song) {
-        return songRepository.findSongsWithMoreLikeCountThanSongWithId(
+        final List<Song> result = songRepository.findSongsWithMoreLikeCountThanSongWithId(
             song.getId(), PageRequest.of(0, BEFORE_SONGS_COUNT)
         );
+
+        Collections.reverse(result);
+        return result;
     }
 
     private List<Song> findAfterSongs(final Song song) {

--- a/backend/src/main/java/shook/shook/song/application/dto/SongSwipeResponse.java
+++ b/backend/src/main/java/shook/shook/song/application/dto/SongSwipeResponse.java
@@ -11,9 +11,9 @@ import shook.shook.song.domain.Song;
 @Getter
 public class SongSwipeResponse {
 
-    private final List<SongResponse> beforeSongs;
+    private final List<SongResponse> prevSongs;
     private final SongResponse currentSong;
-    private final List<SongResponse> afterSongs;
+    private final List<SongResponse> nextSongs;
 
     public static SongSwipeResponse of(
         final Member member,

--- a/backend/src/main/java/shook/shook/song/domain/repository/SongRepository.java
+++ b/backend/src/main/java/shook/shook/song/domain/repository/SongRepository.java
@@ -33,7 +33,7 @@ public interface SongRepository extends JpaRepository<Song, Long> {
         + "GROUP BY s.id "
         + "HAVING (SUM(COALESCE(kp.likeCount, 0)) > (SELECT SUM(COALESCE(kp2.likeCount, 0)) FROM KillingPart kp2 WHERE kp2.song.id = :id) "
         + "OR (SUM(COALESCE(kp.likeCount, 0)) = (SELECT SUM(COALESCE(kp3.likeCount, 0)) FROM KillingPart kp3 WHERE kp3.song.id = :id) AND s.id > :id)) "
-        + "ORDER BY SUM(COALESCE(kp.likeCount, 0)) DESC, s.id DESC")
+        + "ORDER BY SUM(COALESCE(kp.likeCount, 0)), s.id")
     List<Song> findSongsWithMoreLikeCountThanSongWithId(
         @Param("id") final Long songId,
         final Pageable pageable

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -16,6 +16,10 @@ spring:
     hibernate:
       ddl-auto: validate
 
+logging:
+  level:
+    org.hibernate.orm.jdbc.bind: trace
+
 oauth2:
   google:
     access-token-url: http://localhost:8080/token

--- a/backend/src/test/java/shook/shook/song/application/SongServiceTest.java
+++ b/backend/src/test/java/shook/shook/song/application/SongServiceTest.java
@@ -98,8 +98,8 @@ class SongServiceTest extends UsingJpaTest {
 
         //then
         assertAll(
-            () -> assertThat(response.getBeforeSongs()).isEmpty(),
-            () -> assertThat(response.getAfterSongs()).isEmpty(),
+            () -> assertThat(response.getPrevSongs()).isEmpty(),
+            () -> assertThat(response.getNextSongs()).isEmpty(),
             () -> assertThat(response.getCurrentSong().getKillingParts().get(0))
                 .hasFieldOrPropertyWithValue("id",
                     song.getLikeCountSortedKillingParts().get(0).getId())
@@ -134,8 +134,8 @@ class SongServiceTest extends UsingJpaTest {
 
         //then
         assertAll(
-            () -> assertThat(response.getBeforeSongs()).isEmpty(),
-            () -> assertThat(response.getAfterSongs()).isEmpty(),
+            () -> assertThat(response.getPrevSongs()).isEmpty(),
+            () -> assertThat(response.getNextSongs()).isEmpty(),
             () -> assertThat(response.getCurrentSong().getKillingParts().get(0))
                 .hasFieldOrPropertyWithValue("id",
                     song.getLikeCountSortedKillingParts().get(0).getId())
@@ -267,12 +267,12 @@ class SongServiceTest extends UsingJpaTest {
             // then
             assertAll(
                 () -> assertThat(result.getCurrentSong().getId()).isEqualTo(fifthSong.getId()),
-                () -> assertThat(result.getBeforeSongs()).hasSize(2),
-                () -> assertThat(result.getAfterSongs()).hasSize(2),
-                () -> assertThat(result.getBeforeSongs().stream()
+                () -> assertThat(result.getPrevSongs()).hasSize(2),
+                () -> assertThat(result.getNextSongs()).hasSize(2),
+                () -> assertThat(result.getPrevSongs().stream()
                     .map(SongResponse::getId)
                     .toList()).usingRecursiveComparison().isEqualTo(List.of(4L, 3L)),
-                () -> assertThat(result.getAfterSongs().stream()
+                () -> assertThat(result.getNextSongs().stream()
                     .map(SongResponse::getId)
                     .toList()).usingRecursiveComparison().isEqualTo(List.of(2L, 1L))
             );

--- a/backend/src/test/java/shook/shook/song/domain/repository/SongRepositoryTest.java
+++ b/backend/src/test/java/shook/shook/song/domain/repository/SongRepositoryTest.java
@@ -248,7 +248,7 @@ class SongRepositoryTest extends UsingJpaTest {
             .isEqualTo(List.of(thirdSong));
     }
 
-    @DisplayName("주어진 id보다 좋아요가 많은 노래 10개를 조회한다. (데이터가 충분할 때)")
+    @DisplayName("주어진 id보다 좋아요가 많은 노래 10개를 총 좋아요 오름차순, id 오름차순으로 조회한다. (데이터가 충분할 때)")
     @Test
     void findSongsWithMoreLikeCountThanSongWithId() {
         // given
@@ -306,11 +306,11 @@ class SongRepositoryTest extends UsingJpaTest {
         assertThat(songs).usingRecursiveComparison()
             .ignoringFieldsOfTypes(LocalDateTime.class)
             .isEqualTo(
-                List.of(thirdSong, secondSong, firstSong, fifthSong, fourthSong, eleventhSong,
-                    tenthSong, ninthSong, eighthSong, seventhSong));
+                List.of(seventhSong, eighthSong, ninthSong, tenthSong, eleventhSong, fourthSong,
+                    fifthSong, firstSong, secondSong, thirdSong));
     }
 
-    @DisplayName("주어진 id보다 좋아요가 많은 노래 10개를 조회한다. (데이터가 기준보다 부족할 때)")
+    @DisplayName("주어진 id보다 좋아요가 많은 노래 10개를 총 좋아요 오름차순, id 오름차순으로 조회한다. (데이터가 기준보다 부족할 때)")
     @Test
     void findSongsWithMoreLikeCountThanSongWithId_smallData() {
         // given
@@ -358,6 +358,6 @@ class SongRepositoryTest extends UsingJpaTest {
         assertThat(songs).usingRecursiveComparison()
             .ignoringFieldsOfTypes(LocalDateTime.class)
             .isEqualTo(
-                List.of(thirdSong, secondSong, firstSong, fifthSong, fourthSong));
+                List.of(fourthSong, fifthSong, firstSong, secondSong, thirdSong));
     }
 }

--- a/backend/src/test/java/shook/shook/song/ui/SongControllerTest.java
+++ b/backend/src/test/java/shook/shook/song/ui/SongControllerTest.java
@@ -61,9 +61,9 @@ class SongControllerTest {
             .body().as(SongSwipeResponse.class);
 
         //then
-        assertThat(response.getBeforeSongs().get(0).getId()).isEqualTo(1L);
+        assertThat(response.getPrevSongs().get(0).getId()).isEqualTo(1L);
         assertThat(response.getCurrentSong().getId()).isEqualTo(songId);
-        assertThat(response.getAfterSongs().get(0).getId()).isEqualTo(3L);
+        assertThat(response.getNextSongs().get(0).getId()).isEqualTo(3L);
     }
 
     @DisplayName("가장 좋아요가 적은 노래 id 로 이전 노래 정보를 조회할 때 200 상태코드, 이전 노래 리스트를 반환한다.")


### PR DESCRIPTION
## 📝작업 내용

이전 노래 조회 쿼리를 수정한다.

## 💬리뷰 참고사항

기존의 이전 노래 조회 쿼리는 첫 페이지의 결과를 리턴했는데, 마지막 페이지의 결과를 리턴하는 것이 옳은 작동 방식이었습니다.
그래서 노래 조회 쿼리를 좋아요 순 ASC, id 순 ASC 로 정렬하도록 변경했습니다.

## #️⃣연관된 이슈

closes #293


