### PR TITLE
Hotfix/#299 VotingSongSwipeResponse 필드 이름을 수정한다

### DIFF
--- a/backend/src/main/java/shook/shook/song/application/dto/SongSwipeResponse.java
+++ b/backend/src/main/java/shook/shook/song/application/dto/SongSwipeResponse.java
@@ -18,33 +18,33 @@ public class SongSwipeResponse {
     public static SongSwipeResponse of(
         final Member member,
         final Song currentSong,
-        final List<Song> beforeSongs,
-        final List<Song> afterSongs
+        final List<Song> prevSongs,
+        final List<Song> nextSongs
     ) {
         final SongResponse currentResponse = SongResponse.of(currentSong, member);
-        final List<SongResponse> beforeResponses = beforeSongs.stream()
+        final List<SongResponse> prevResponses = prevSongs.stream()
             .map(song -> SongResponse.of(song, member))
             .toList();
-        final List<SongResponse> afterResponses = afterSongs.stream()
+        final List<SongResponse> nextResponses = nextSongs.stream()
             .map(song -> SongResponse.of(song, member))
             .toList();
 
-        return new SongSwipeResponse(beforeResponses, currentResponse, afterResponses);
+        return new SongSwipeResponse(prevResponses, currentResponse, nextResponses);
     }
 
     public static SongSwipeResponse ofUnauthorizedUser(
         final Song currentSong,
-        final List<Song> beforeSongs,
-        final List<Song> afterSongs
+        final List<Song> prevSongs,
+        final List<Song> nextSongs
     ) {
         final SongResponse currentResponse = SongResponse.fromUnauthorizedUser(currentSong);
-        final List<SongResponse> beforeResponses = beforeSongs.stream()
+        final List<SongResponse> prevResponses = prevSongs.stream()
             .map(SongResponse::fromUnauthorizedUser)
             .toList();
-        final List<SongResponse> afterResponses = afterSongs.stream()
+        final List<SongResponse> nextResponses = nextSongs.stream()
             .map(SongResponse::fromUnauthorizedUser)
             .toList();
 
-        return new SongSwipeResponse(beforeResponses, currentResponse, afterResponses);
+        return new SongSwipeResponse(prevResponses, currentResponse, nextResponses);
     }
 }

--- a/backend/src/main/java/shook/shook/voting_song/application/dto/VotingSongSwipeResponse.java
+++ b/backend/src/main/java/shook/shook/voting_song/application/dto/VotingSongSwipeResponse.java
@@ -13,22 +13,22 @@ import shook.shook.voting_song.domain.VotingSong;
 public class VotingSongSwipeResponse {
 
     private VotingSongResponse currentSong;
-    private List<VotingSongResponse> beforeSongs;
-    private List<VotingSongResponse> afterSongs;
+    private List<VotingSongResponse> prevSongs;
+    private List<VotingSongResponse> nextSongs;
 
     public static VotingSongSwipeResponse of(
         final VotingSong currentSong,
-        final List<VotingSong> beforeSongs,
-        final List<VotingSong> afterSongs
+        final List<VotingSong> prevSongs,
+        final List<VotingSong> nextSongs
     ) {
         final VotingSongResponse currentResponse = VotingSongResponse.from(currentSong);
-        final List<VotingSongResponse> beforeResponses = beforeSongs.stream()
+        final List<VotingSongResponse> prevResponses = prevSongs.stream()
             .map(VotingSongResponse::from)
             .toList();
-        final List<VotingSongResponse> afterResponses = afterSongs.stream()
+        final List<VotingSongResponse> nextResponses = nextSongs.stream()
             .map(VotingSongResponse::from)
             .toList();
 
-        return new VotingSongSwipeResponse(currentResponse, beforeResponses, afterResponses);
+        return new VotingSongSwipeResponse(currentResponse, prevResponses, nextResponses);
     }
 }

--- a/backend/src/test/java/shook/shook/voting_song/application/VotingSongServiceTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/application/VotingSongServiceTest.java
@@ -150,9 +150,9 @@ class VotingSongServiceTest extends UsingJpaTest {
                     .toList();
 
             assertAll(
-                () -> assertThat(swipeResponse.getBeforeSongs()).usingRecursiveComparison()
+                () -> assertThat(swipeResponse.getPrevSongs()).usingRecursiveComparison()
                     .isEqualTo(expectedBefore),
-                () -> assertThat(swipeResponse.getAfterSongs()).usingRecursiveComparison()
+                () -> assertThat(swipeResponse.getNextSongs()).usingRecursiveComparison()
                     .isEqualTo(expectedAfter),
                 () -> assertThat(swipeResponse.getCurrentSong()).usingRecursiveComparison()
                     .isEqualTo(expectedCurrent)

--- a/backend/src/test/java/shook/shook/voting_song/ui/VotingSongControllerTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/ui/VotingSongControllerTest.java
@@ -55,11 +55,11 @@ class VotingSongControllerTest extends AcceptanceTest {
     @Test
     void findById() {
         // given
-        final VotingSong beforeSong = votingSongRepository.save(
+        final VotingSong prevSong = votingSongRepository.save(
             new VotingSong("제목1", "비디오ID는 11글자", "이미지URL", "가수", 20));
         final VotingSong standardSong = votingSongRepository.save(
             new VotingSong("제목2", "비디오ID는 11글자", "이미지URL", "가수", 20));
-        final VotingSong afterSong = votingSongRepository.save(
+        final VotingSong nextSong = votingSongRepository.save(
             new VotingSong("제목3", "비디오ID는 11글자", "이미지URL", "가수", 20));
 
         // when
@@ -72,20 +72,20 @@ class VotingSongControllerTest extends AcceptanceTest {
             .body().as(VotingSongSwipeResponse.class);
 
         // then
-        final List<VotingSongResponse> expectedBefore = Stream.of(beforeSong)
+        final List<VotingSongResponse> expectedPrev = Stream.of(prevSong)
             .map(VotingSongResponse::from)
             .toList();
-        final List<VotingSongResponse> expectedAfter = Stream.of(afterSong)
+        final List<VotingSongResponse> expectedNext = Stream.of(nextSong)
             .map(VotingSongResponse::from)
             .toList();
 
         assertAll(
-            () -> assertThat(response.getBeforeSongs()).usingRecursiveComparison()
-                .isEqualTo(expectedBefore),
+            () -> assertThat(response.getPrevSongs()).usingRecursiveComparison()
+                .isEqualTo(expectedPrev),
             () -> assertThat(response.getCurrentSong()).usingRecursiveComparison()
                 .isEqualTo(VotingSongResponse.from(standardSong)),
-            () -> assertThat(response.getAfterSongs()).usingRecursiveComparison()
-                .isEqualTo(expectedAfter)
+            () -> assertThat(response.getNextSongs()).usingRecursiveComparison()
+                .isEqualTo(expectedNext)
         );
     }
 
@@ -93,7 +93,7 @@ class VotingSongControllerTest extends AcceptanceTest {
     @Test
     void findByIdEmptyAfterSong() {
         // given
-        final VotingSong beforeSong = votingSongRepository.save(
+        final VotingSong prevSong = votingSongRepository.save(
             new VotingSong("제목1", "비디오ID는 11글자", "이미지URL", "가수", 20));
         final VotingSong standardSong = votingSongRepository.save(
             new VotingSong("제목2", "비디오ID는 11글자", "이미지URL", "가수", 20));
@@ -108,16 +108,16 @@ class VotingSongControllerTest extends AcceptanceTest {
             .body().as(VotingSongSwipeResponse.class);
 
         // then
-        final List<VotingSongResponse> expectedBefore = Stream.of(beforeSong)
+        final List<VotingSongResponse> expectedPrev = Stream.of(prevSong)
             .map(VotingSongResponse::from)
             .toList();
 
         assertAll(
-            () -> assertThat(response.getBeforeSongs()).usingRecursiveComparison()
-                .isEqualTo(expectedBefore),
+            () -> assertThat(response.getPrevSongs()).usingRecursiveComparison()
+                .isEqualTo(expectedPrev),
             () -> assertThat(response.getCurrentSong()).usingRecursiveComparison()
                 .isEqualTo(VotingSongResponse.from(standardSong)),
-            () -> assertThat(response.getAfterSongs()).isEmpty()
+            () -> assertThat(response.getNextSongs()).isEmpty()
         );
     }
 
@@ -127,7 +127,7 @@ class VotingSongControllerTest extends AcceptanceTest {
         // given
         final VotingSong standardSong = votingSongRepository.save(
             new VotingSong("제목1", "비디오ID는 11글자", "이미지URL", "가수", 20));
-        final VotingSong afterSong = votingSongRepository.save(
+        final VotingSong nextSong = votingSongRepository.save(
             new VotingSong("제목2", "비디오ID는 11글자", "이미지URL", "가수", 20));
 
         // when
@@ -140,16 +140,16 @@ class VotingSongControllerTest extends AcceptanceTest {
             .body().as(VotingSongSwipeResponse.class);
 
         // then
-        final List<VotingSongResponse> expectedAfter = Stream.of(afterSong)
+        final List<VotingSongResponse> expectedNext = Stream.of(nextSong)
             .map(VotingSongResponse::from)
             .toList();
 
         assertAll(
-            () -> assertThat(response.getBeforeSongs()).isEmpty(),
+            () -> assertThat(response.getPrevSongs()).isEmpty(),
             () -> assertThat(response.getCurrentSong()).usingRecursiveComparison()
                 .isEqualTo(VotingSongResponse.from(standardSong)),
-            () -> assertThat(response.getAfterSongs()).usingRecursiveComparison()
-                .isEqualTo(expectedAfter)
+            () -> assertThat(response.getNextSongs()).usingRecursiveComparison()
+                .isEqualTo(expectedNext)
         );
     }
 }


### PR DESCRIPTION
## 📝작업 내용

VotingSongSwipeResponse 필드 이름을 수정한다.

## 💬리뷰 참고사항

전체적으로 before -> prev, after -> next 로 변경한다.

## #️⃣연관된 이슈

closes #299


