### PR TITLE
Feat/#337 스와이프 페이지 이동 시 기존 재생 노래 멈춤 기능을 구현한다. 

### DIFF
--- a/frontend/src/features/youtube/components/Youtube.tsx
+++ b/frontend/src/features/youtube/components/Youtube.tsx
@@ -18,7 +18,7 @@ const Youtube = ({ videoId, start = 0 }: YoutubeProps) => {
           videoId,
           width: '100%',
           height: '100%',
-          playerVars: { start, rel: 0 },
+          playerVars: { start, rel: 0, fs: 0 },
           events: {
             onReady: (e) => {
               bindUpdatePlayerStateEvent(e);


### PR DESCRIPTION
## 📝작업 내용

스와이프 페이지 이동 시 기존 재생 노래 멈춤 기능을 구현한다. 

## 💬리뷰 참고사항

인터섹션 옵저버로 화면 절반 이상 넘어가면 노래 멈추도록 구현했습니다!

## #️⃣연관된 이슈

close #337


