### PR TITLE
fix: like 개수 상태를 두어 새로고침 뒤에 정합성 유지

### DIFF
--- a/frontend/src/features/songs/hooks/useKillingPartLikes.ts
+++ b/frontend/src/features/songs/hooks/useKillingPartLikes.ts
@@ -18,13 +18,19 @@ const useKillingPartLikes = ({
   songId,
 }: UseKillingPartLikesProps) => {
   const [isLikes, setIsLikes] = useState(likeStatus);
+  const [calculatedLikeCount, setCalculatedLikeCount] = useState(likeCount);
   const LikesTimeOutRef = useRef<number | null>(null);
   const { mutateData: mutateKillingPartLikes } = useMutation(putKillingPartLikes);
-  const calculatedLikeCount = isLikes ? likeCount + 1 : likeCount;
   const heartIcon = isLikes ? fillHeartIcon : emptyHeartIcon;
 
   const toggleKillingPartLikes = () => {
     setIsLikes((prev) => !prev);
+
+    if (isLikes) {
+      setCalculatedLikeCount((prev) => prev - 1);
+    } else {
+      setCalculatedLikeCount((prev) => prev + 1);
+    }
 
     if (LikesTimeOutRef.current) {
       window.clearTimeout(LikesTimeOutRef.current);

--- a/frontend/src/features/songs/hooks/useKillingPartLikes.ts
+++ b/frontend/src/features/songs/hooks/useKillingPartLikes.ts
@@ -25,12 +25,7 @@ const useKillingPartLikes = ({
 
   const toggleKillingPartLikes = () => {
     setIsLikes((prev) => !prev);
-
-    if (isLikes) {
-      setCalculatedLikeCount((prev) => prev - 1);
-    } else {
-      setCalculatedLikeCount((prev) => prev + 1);
-    }
+    setCalculatedLikeCount((prev) => (isLikes ? prev - 1 : prev + 1));
 
     if (LikesTimeOutRef.current) {
       window.clearTimeout(LikesTimeOutRef.current);


### PR DESCRIPTION
## 📝작업 내용

킬링파트 좋아요를 누른 뒤 새로고침할 경우 좋아요 개수가 하나 더해져 있는 버그를 수정함.


## #️⃣연관된 이슈

close #335


