### PR TITLE
Fix/#333 노래 상세정보 추가 fetch를 위한 인터섹션 옵저버 오류 수정

### DIFF
--- a/frontend/src/pages/SongDetailListPage.tsx
+++ b/frontend/src/pages/SongDetailListPage.tsx
@@ -9,7 +9,6 @@ import {
 } from '@/features/songs/remotes/songs';
 import useExtraFetch from '@/shared/hooks/useExtraFetch';
 import useFetch from '@/shared/hooks/useFetch';
-import createObserver from '@/shared/utils/createObserver';
 
 const SongDetailListPage = () => {
   const { id: songIdParams } = useParams();
@@ -33,11 +32,13 @@ const SongDetailListPage = () => {
   useEffect(() => {
     if (!prevTargetRef.current) return;
 
-    const firstSongId = prevTargetRef.current?.nextElementSibling?.getAttribute(
-      'data-song-id'
-    ) as string;
+    const prevObserver = new IntersectionObserver(([entry]) => {
+      if (!entry.isIntersecting) return;
 
-    const prevObserver = createObserver(() => fetchExtraPrevSongDetails(Number(firstSongId)));
+      const firstSongId = entry.target.nextElementSibling?.getAttribute('data-song-id') as string;
+
+      fetchExtraPrevSongDetails(Number(firstSongId));
+    });
 
     prevObserver.observe(prevTargetRef.current);
 
@@ -47,11 +48,15 @@ const SongDetailListPage = () => {
   useEffect(() => {
     if (!nextTargetRef.current) return;
 
-    const lastSongId = nextTargetRef.current?.previousElementSibling?.getAttribute(
-      'data-song-id'
-    ) as string;
+    const nextObserver = new IntersectionObserver(([entry]) => {
+      if (!entry.isIntersecting) return;
 
-    const nextObserver = createObserver(() => fetchExtraNextSongDetails(Number(lastSongId)));
+      const lastSongId = entry.target.previousElementSibling?.getAttribute(
+        'data-song-id'
+      ) as string;
+
+      fetchExtraNextSongDetails(Number(lastSongId));
+    });
 
     nextObserver.observe(nextTargetRef.current);
 

--- a/frontend/src/pages/SongDetailListPage.tsx
+++ b/frontend/src/pages/SongDetailListPage.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/features/songs/remotes/songs';
 import useExtraFetch from '@/shared/hooks/useExtraFetch';
 import useFetch from '@/shared/hooks/useFetch';
+import createObserver from '@/shared/utils/createObserver';
 
 const SongDetailListPage = () => {
   const { id: songIdParams } = useParams();
@@ -29,17 +30,26 @@ const SongDetailListPage = () => {
   const prevTargetRef = useRef<HTMLDivElement | null>(null);
   const nextTargetRef = useRef<HTMLDivElement | null>(null);
 
+  const getFirstSongId = () => {
+    const firstSongId = prevTargetRef.current?.nextElementSibling?.getAttribute(
+      'data-song-id'
+    ) as string;
+
+    return Number(firstSongId);
+  };
+
+  const getLastSongId = () => {
+    const lastSongId = nextTargetRef.current?.previousElementSibling?.getAttribute(
+      'data-song-id'
+    ) as string;
+
+    return Number(lastSongId);
+  };
+
   useEffect(() => {
     if (!prevTargetRef.current) return;
 
-    const prevObserver = new IntersectionObserver(([entry]) => {
-      if (!entry.isIntersecting) return;
-
-      const firstSongId = entry.target.nextElementSibling?.getAttribute('data-song-id') as string;
-
-      fetchExtraPrevSongDetails(Number(firstSongId));
-    });
-
+    const prevObserver = createObserver(() => fetchExtraPrevSongDetails(getFirstSongId()));
     prevObserver.observe(prevTargetRef.current);
 
     return () => prevObserver.disconnect();
@@ -48,16 +58,7 @@ const SongDetailListPage = () => {
   useEffect(() => {
     if (!nextTargetRef.current) return;
 
-    const nextObserver = new IntersectionObserver(([entry]) => {
-      if (!entry.isIntersecting) return;
-
-      const lastSongId = entry.target.previousElementSibling?.getAttribute(
-        'data-song-id'
-      ) as string;
-
-      fetchExtraNextSongDetails(Number(lastSongId));
-    });
-
+    const nextObserver = createObserver(() => fetchExtraNextSongDetails(getLastSongId()));
     nextObserver.observe(nextTargetRef.current);
 
     return () => nextObserver.disconnect();

--- a/frontend/src/pages/SongDetailListPage.tsx
+++ b/frontend/src/pages/SongDetailListPage.tsx
@@ -13,14 +13,15 @@ import useFetch from '@/shared/hooks/useFetch';
 const SongDetailListPage = () => {
   const { id: songIdParams } = useParams();
   const { data: songDetailEntries } = useFetch(() => getSongDetailEntries(Number(songIdParams)));
-  const { data: extraNextSongDetails, fetchData: fetchExtraNextSongDetails } = useExtraFetch(
-    getExtraNextSongDetails,
-    'down'
-  );
 
   const { data: extraPrevSongDetails, fetchData: fetchExtraPrevSongDetails } = useExtraFetch(
     getExtraPrevSongDetails,
-    'top'
+    'prev'
+  );
+
+  const { data: extraNextSongDetails, fetchData: fetchExtraNextSongDetails } = useExtraFetch(
+    getExtraNextSongDetails,
+    'next'
   );
 
   const itemRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/shared/hooks/useExtraFetch.ts
+++ b/frontend/src/shared/hooks/useExtraFetch.ts
@@ -1,7 +1,7 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { ErrorResponse } from '@/shared/remotes';
 
-type FetchDirection = 'top' | 'down';
+type FetchDirection = 'prev' | 'next';
 
 const useExtraFetch = <T, P>(
   extraFetcher: (...params: P[]) => Promise<T[]>,
@@ -19,21 +19,18 @@ const useExtraFetch = <T, P>(
       try {
         const extraData = await extraFetcher(...params);
 
-        if (fetchDirection === 'top') {
-          const newData = extraData.concat(data);
-          setData(newData);
-          return;
+        if (fetchDirection === 'prev') {
+          setData((prevData) => [...extraData, ...prevData]);
+        } else {
+          setData((prevData) => [...prevData, ...extraData]);
         }
-
-        const newData = data.concat(extraData);
-        setData(newData);
       } catch (error) {
         setError(error as ErrorResponse);
       } finally {
         setIsLoading(false);
       }
     },
-    [data, extraFetcher, fetchDirection]
+    [extraFetcher, fetchDirection]
   );
 
   return { data, isLoading, error, fetchData };

--- a/frontend/src/shared/hooks/useExtraFetch.ts
+++ b/frontend/src/shared/hooks/useExtraFetch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { ErrorResponse } from '@/shared/remotes';
 
 type FetchDirection = 'prev' | 'next';

--- a/frontend/src/shared/utils/createObserver.ts
+++ b/frontend/src/shared/utils/createObserver.ts
@@ -1,0 +1,9 @@
+const createObserver = (onIntersecting: () => void, options?: IntersectionObserverInit) => {
+  return new IntersectionObserver(([entry]) => {
+    if (entry.isIntersecting) {
+      onIntersecting();
+    }
+  }, options);
+};
+
+export default createObserver;


### PR DESCRIPTION
## 📝작업 내용


### fetch 정상 작동하도록 로직 수정

![image](https://github.com/woowacourse-teams/2023-shook/assets/77152650/4d4ca7df-d266-46b7-b1ce-75f71e74280d)


## 💬리뷰 참고사항

1ref + 1effect 로 옵져버 실행시키는 구조입니다.
첫 노래 상세정보 API 응답 **이후에** 옵져버를 실행시켜야 하는등 제약 조건이 조금 있어서 로직이 많아 졌어요
관련해서 api가 수정되면 좋을 것 같아서 건의해둔 상태입니다!


### DOM 구조

현재 관련해서 API 수정 건의가 진행중입니다~!
개선되면 로직도 가벼워지고, DOM 구조 역시 더 간단해질 것 같아요.

**as is :** extraPrev, prev, next, extraNext 총 4개의 데이터 배엘에 map() 
**to be :**  prev, next 총 2개의 데이터 배열에 map()

### 선 배포
원래 사용자에게 제공되야 했던 기능이었어서 
#333 bug fix브랜치 기준으로 prod 배포 미리 나갔습니다!

## #️⃣연관된 이슈

close #333 


