### PR TITLE
Feat/#371: 회원 탈퇴 기능 구현

### DIFF
--- a/backend/src/main/java/shook/shook/auth/config/AuthConfig.java
+++ b/backend/src/main/java/shook/shook/auth/config/AuthConfig.java
@@ -44,7 +44,8 @@ public class AuthConfig implements WebMvcConfigurer {
             .includePathPattern("/my-page", PathMethod.GET)
             .includePathPattern("/songs/*/parts/*/likes", PathMethod.PUT)
             .includePathPattern("/voting-songs/*/parts", PathMethod.POST)
-            .includePathPattern("/songs/*/parts/*/comments", PathMethod.POST);
+            .includePathPattern("/songs/*/parts/*/comments", PathMethod.POST)
+            .includePathPattern("/members/*", PathMethod.DELETE);
     }
 
     @Override

--- a/backend/src/main/java/shook/shook/auth/exception/AuthorizationException.java
+++ b/backend/src/main/java/shook/shook/auth/exception/AuthorizationException.java
@@ -38,4 +38,15 @@ public class AuthorizationException extends CustomException {
             super(ErrorCode.ACCESS_TOKEN_NOT_FOUND);
         }
     }
+
+    public static class UnauthenticatedException extends AuthorizationException {
+
+        public UnauthenticatedException(final Map<String, String> inputValuesByProperty) {
+            super(ErrorCode.UNAUTHENTICATED_EXCEPTION, inputValuesByProperty);
+        }
+
+        public UnauthenticatedException() {
+            super(ErrorCode.UNAUTHENTICATED_EXCEPTION);
+        }
+    }
 }

--- a/backend/src/main/java/shook/shook/globalexception/ErrorCode.java
+++ b/backend/src/main/java/shook/shook/globalexception/ErrorCode.java
@@ -17,6 +17,8 @@ public enum ErrorCode {
     GOOGLE_SERVER_EXCEPTION(1005, "구글 서버에서 오류가 발생했습니다."),
     REFRESH_TOKEN_NOT_FOUND_EXCEPTION(1006, "accessToken 을 재발급하기 위해서는 refreshToken 이 필요합니다."),
     ACCESS_TOKEN_NOT_FOUND(1007, "accessToken이 필요합니다."),
+    UNAUTHENTICATED_EXCEPTION(1008, "권한이 없는 요청입니다."),
+
     // 2000: 킬링파트 - 좋아요, 댓글
 
     EMPTY_KILLING_PART_COMMENT(2001, "킬링파트 댓글은 비어있을 수 없습니다."),

--- a/backend/src/main/java/shook/shook/globalexception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/shook/shook/globalexception/GlobalExceptionHandler.java
@@ -63,6 +63,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(ErrorResponse.from(e));
     }
 
+    @ExceptionHandler(AuthorizationException.UnauthenticatedException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthenticatedException(final CustomException e) {
+        log.error(e.getErrorInfoLog());
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ErrorResponse.from(e));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleRequestValidationException(
         final MethodArgumentNotValidException e

--- a/backend/src/main/java/shook/shook/member/application/MemberService.java
+++ b/backend/src/main/java/shook/shook/member/application/MemberService.java
@@ -46,6 +46,7 @@ public class MemberService {
             );
     }
 
+    @Transactional
     public void deleteById(final Long id, final MemberInfo memberInfo) {
         final long requestMemberId = memberInfo.getMemberId();
         final Member requestMember = findById(requestMemberId);

--- a/backend/src/main/java/shook/shook/member/application/MemberService.java
+++ b/backend/src/main/java/shook/shook/member/application/MemberService.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import shook.shook.auth.exception.AuthorizationException;
+import shook.shook.auth.ui.argumentresolver.MemberInfo;
 import shook.shook.member.domain.Email;
 import shook.shook.member.domain.Member;
 import shook.shook.member.domain.Nickname;
@@ -42,5 +44,33 @@ public class MemberService {
                     Map.of("Id", String.valueOf(id), "Nickname", nickname.getValue())
                 )
             );
+    }
+
+    public void deleteById(final Long id, final MemberInfo memberInfo) {
+        final long requestMemberId = memberInfo.getMemberId();
+        final Member requestMember = findById(requestMemberId);
+        final Member targetMember = findById(id);
+        validateMemberAuthentication(requestMember, targetMember);
+
+        memberRepository.delete(targetMember);
+    }
+
+    private Member findById(final Long id) {
+        return memberRepository.findById(id)
+            .orElseThrow(() -> new MemberException.MemberNotExistException(
+                Map.of("Id", String.valueOf(id))
+            ));
+    }
+
+    private void validateMemberAuthentication(final Member requestMember,
+        final Member targetMember) {
+        if (!requestMember.equals(targetMember)) {
+            throw new AuthorizationException.UnauthenticatedException(
+                Map.of(
+                    "tokenMemberId", String.valueOf(requestMember.getId()),
+                    "pathMemberId", String.valueOf(targetMember.getId())
+                )
+            );
+        }
     }
 }

--- a/backend/src/main/java/shook/shook/member/ui/MemberController.java
+++ b/backend/src/main/java/shook/shook/member/ui/MemberController.java
@@ -1,0 +1,31 @@
+package shook.shook.member.ui;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shook.shook.auth.ui.argumentresolver.Authenticated;
+import shook.shook.auth.ui.argumentresolver.MemberInfo;
+import shook.shook.member.application.MemberService;
+import shook.shook.member.ui.openapi.MemberApi;
+
+@RequiredArgsConstructor
+@RequestMapping("/members/{member_id}")
+@RestController
+public class MemberController implements MemberApi {
+
+    private final MemberService memberService;
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteMember(
+        @PathVariable(name = "member_id") final Long memberId,
+        @Authenticated final MemberInfo memberInfo
+    ) {
+        memberService.deleteById(memberId, memberInfo);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/backend/src/main/java/shook/shook/member/ui/openapi/MemberApi.java
+++ b/backend/src/main/java/shook/shook/member/ui/openapi/MemberApi.java
@@ -1,0 +1,34 @@
+package shook.shook.member.ui.openapi;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import shook.shook.auth.ui.argumentresolver.Authenticated;
+import shook.shook.auth.ui.argumentresolver.MemberInfo;
+
+@Tag(name = "Member", description = "회원 관리 API")
+public interface MemberApi {
+
+    @Operation(
+        summary = "회원 탈퇴",
+        description = "회원 탈퇴로 회원을 삭제한다."
+    )
+    @ApiResponse(
+        responseCode = "204",
+        description = "회원 탈퇴, 삭제 성공"
+    )
+    @Parameter(
+        name = "member_id",
+        description = "삭제할 회원 id",
+        required = true
+    )
+    @DeleteMapping
+    ResponseEntity<Void> deleteMember(
+        @PathVariable(name = "member_id") final Long memberId,
+        @Authenticated final MemberInfo memberInfo
+    );
+}

--- a/backend/src/main/resources/dev/data.sql
+++ b/backend/src/main/resources/dev/data.sql
@@ -2,24 +2,19 @@ TRUNCATE TABLE song;
 TRUNCATE TABLE voting_song;
 
 insert into voting_song (title, singer, length, video_id, album_cover_url, created_at)
-values ('달빛소년', '체리필터 (cherryfilter)', 241, 'MENOHM2a8Oo', 'https://image.genie.co.kr/Y/IMAGE/IMG_ALBUM/015/027/236/15027236_1319188420285_1_600x600.JPG/dims/resize/Q_80,0', now());
+values ('N.Y.C.T', 'NCT U', 241, '8umUXHLGl3o', 'https://cdnimg.melon.co.kr/cm2/album/images/113/22/590/11322590_20230907111726_500.jpg?3d8bcc03a4900fdba3f199390f432b24/melon/resize/140/quality/80/optimize', now());
 
 insert into voting_song (title, singer, length, video_id, album_cover_url, created_at)
-values ('Happy Day', '체리필터 (cherryfilter)', 216, '6CFs-4if788', 'https://image.genie.co.kr/Y/IMAGE/IMG_ALBUM/041/719/050/41719050_1319703431175_1_600x600.JPG/dims/resize/Q_80,0', now());
+values ('Slow Dancing', 'V', 190, 'eI0iTRS0Ha8', 'https://cdnimg.melon.co.kr/cm2/album/images/113/03/638/11303638_20230811103847_500.jpg?92b308988cd1521e8bd4d9c2f56768ed/melon/resize/140/quality/80/optimize', now());
 
 insert into voting_song (title, singer, length, video_id, album_cover_url, created_at)
-values ('낭만 고양이', '체리필터 (cherryfilter)', 228, 'Nh5Ld4EpXJs', 'https://image.genie.co.kr/Y/IMAGE/IMG_ALBUM/015/026/138/15026138_1406191371950_1_600x600.JPG/dims/resize/Q_80,0', now());
+values ('LET''S DANCE', '이채연', 222, 'kQFLWdjk_8s', 'https://cdnimg.melon.co.kr/cm2/album/images/113/19/933/11319933_20230905152508_500.jpg?2bc0bb896e182ebb6ab11119b40657bc/melon/resize/140/quality/80/optimize', now());
 
 insert into voting_song (title, singer, length, video_id, album_cover_url, created_at)
-values ('오리날다 (영화 ''권순분여사 납치사건'' CF 테마송)', '체리필터 (cherryfilter)', 246, 'ivbdRCDCOig', 'https://image.genie.co.kr/Y/IMAGE/IMG_ALBUM/015/027/236/15027236_1319188420285_1_600x600.JPG/dims/resize/Q_80,0', now());
+values ('Smoke (Prod. Dynamicduo, Padi)', '다이나믹 듀오, 이영지', 210, 'ZwXzaqzRVi4', 'https://cdnimg.melon.co.kr/cm2/album/images/113/15/612/11315612_20230905120657_500.jpg?e9f1ae79ad72f3749b9678e7ebd90027/melon/resize/140/quality/80/optimize', now());
 
 insert into voting_song (title, singer, length, video_id, album_cover_url, created_at)
-values ('피아니시모 (Pianissimo)', '체리필터 (cherryfilter)', 229, 'VxnWkErj2TE', 'https://image.genie.co.kr/Y/IMAGE/IMG_ALBUM/079/949/993/79949993_1398756703913_1_600x600.JPG/dims/resize/Q_80,0', now());
-
-INSERT INTO song (title, singer, length, video_id, album_cover_url, created_at)
-VALUES ('취중고백', '김민석 (멜로망스)', 258, 'FCrMKhrFH7A',
-        'https://cdnimg.melon.co.kr/cm2/album/images/108/16/959/10816959_20211217144957_500.jpg?c1818ddc493cb2bbb4d268431e6de7b5/melon/resize/282/quality/80/optimize',
-        now());
+values ('뭣 같아', 'BOYNEXTDOOR', 180, '97_-_WugRFA', 'https://cdnimg.melon.co.kr/cm2/album/images/113/19/182/11319182_20230904102829_500.jpg?6555bb763ac1707683f5d05c0ab1b496/melon/resize/140/quality/80/optimize', now());
 
 INSERT INTO killing_part(start_second, length, song_id, like_count, created_at)
 VALUES (5, 'SHORT', 1, 10, now());

--- a/backend/src/test/java/shook/shook/exceptionhandler/ControllerAdviceTest.java
+++ b/backend/src/test/java/shook/shook/exceptionhandler/ControllerAdviceTest.java
@@ -25,7 +25,7 @@ import shook.shook.voting_song.exception.VoteException;
 import shook.shook.voting_song.exception.VotingSongException;
 import shook.shook.voting_song.exception.VotingSongPartException;
 
-public class ControllerAdviceTest extends AcceptanceTest {
+class ControllerAdviceTest extends AcceptanceTest {
 
     @MockBean
     private SongService mockedService;
@@ -33,7 +33,7 @@ public class ControllerAdviceTest extends AcceptanceTest {
     @DisplayName("Controller Advice를 테스트한다.")
     @ParameterizedTest
     @MethodSource("exceptionTestData")
-    public void testGlobalExceptionHandler(ExceptionTestData testData) {
+    void testGlobalExceptionHandler(ExceptionTestData testData) {
         given(mockedService.showHighLikedSongs()).willThrow(testData.getException());
 
         RestAssured.given().log().all()
@@ -53,6 +53,7 @@ public class ControllerAdviceTest extends AcceptanceTest {
             new ExceptionTestData(new OAuthException.GoogleServerException(), 503),
             new ExceptionTestData(new AuthorizationException.AccessTokenNotFoundException(), 401),
             new ExceptionTestData(new AuthorizationException.RefreshTokenNotFoundException(), 401),
+            new ExceptionTestData(new AuthorizationException.UnauthenticatedException(), 403),
             new ExceptionTestData(new MemberException.MemberNotExistException(), 401),
 
             new ExceptionTestData(new KillingPartCommentException.NullOrEmptyPartCommentException(),

--- a/backend/src/test/java/shook/shook/member/ui/MemberControllerTest.java
+++ b/backend/src/test/java/shook/shook/member/ui/MemberControllerTest.java
@@ -1,0 +1,56 @@
+package shook.shook.member.ui;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import shook.shook.auth.application.TokenProvider;
+import shook.shook.member.domain.Member;
+import shook.shook.member.domain.repository.MemberRepository;
+import shook.shook.support.AcceptanceTest;
+
+class MemberControllerTest extends AcceptanceTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @DisplayName("회원 삭제시 204 상태코드와 함께 비어있는 body 응답이 반환된다.")
+    @Test
+    void deleteMember() {
+        // given
+        final Member member = memberRepository.save(new Member("hi@naver.com", "hi"));
+        final String accessToken = tokenProvider.createAccessToken(member.getId(),
+            member.getNickname());
+
+        // when, then
+        RestAssured.given().log().all()
+            .when().log().all()
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+            .delete("/members/{member_id}", member.getId())
+            .then().log().all()
+            .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @DisplayName("회원 삭제시 api path에 담긴 회원 id와 토큰에 담긴 회원 id가 다르다면 403 상태코드가 반환된다.")
+    @Test
+    void deleteMember_forbidden() {
+        // given
+        final Member member = memberRepository.save(new Member("hi@naver.com", "hi"));
+        final Member requestMember = memberRepository.save(new Member("new@naver.com", "new"));
+        final String accessToken = tokenProvider.createAccessToken(requestMember.getId(),
+            requestMember.getNickname());
+
+        // when, then
+        RestAssured.given().log().all()
+            .when().log().all()
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+            .delete("/members/{member_id}", member.getId())
+            .then().log().all()
+            .statusCode(HttpStatus.FORBIDDEN.value());
+    }
+}


### PR DESCRIPTION
## 📝작업 내용

회원이 **자발적으로** 탈퇴할 때, 회원을 삭제하는 기능을 구현했습니다.
- [x] 토큰에 담긴 회원과 요청 URL에 담긴 id의 회원이 동일하지 않다면 `UNAUTHENTICATED` 예외가 발생, `403 FORBIDDEN` 응답이 반환됩니다.
- [x] 어케저케.. 베로의 Swagger 인터페이스를 참고하여 스웨거 설정을 했습니다.

## 💬리뷰 참고사항

- 특정 id의 member를 삭제한다는 의미이기 때문에 URL을 `members/{member_id}` 로 설정했습니다.
- 아코에게서는 현장에서 코드 리뷰를 받았습니다 ^^

## #️⃣연관된 이슈

closes #371
#382 

