### PR TITLE
Feat#388: 엑셀 파일을 통해 노래 데이터 등록 API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -46,6 +46,10 @@ dependencies {
 
     //log to slack
     implementation 'com.github.maricn:logback-slack-appender:1.4.0'
+
+    //xlsx reader
+    implementation group: 'org.apache.poi', name: 'poi', version: '5.0.0'
+    implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.0.0'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/shook/shook/globalexception/ErrorCode.java
+++ b/backend/src/main/java/shook/shook/globalexception/ErrorCode.java
@@ -46,6 +46,8 @@ public enum ErrorCode {
     TOO_LONG_SONG_IMAGE_URL(3008, "노래 앨범 커버 URL은 65,356자를 넘길 수 없습니다."),
     EMPTY_SINGER_NAME(3009, "가수 이름은 비어있을 수 없습니다."),
     TOO_LONG_SINGER_NAME(3010, "가수 이름은 50글자를 넘길 수 없습니다."),
+    CAN_NOT_READ_SONG_DATA_FILE(3011, "노래 데이터 파일을 읽을 수 없습니다."),
+    SONG_ALREADY_EXIST(3012, "등록하려는 노래가 이미 존재합니다."),
 
     // 4000: 투표
     VOTING_PART_START_LESS_THAN_ZERO(4001, "파트의 시작 초는 0보다 작을 수 없습니다."),

--- a/backend/src/main/java/shook/shook/song/application/SongDataExcelReader.java
+++ b/backend/src/main/java/shook/shook/song/application/SongDataExcelReader.java
@@ -1,0 +1,138 @@
+package shook.shook.song.application;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import shook.shook.part.domain.PartLength;
+import shook.shook.song.domain.KillingParts;
+import shook.shook.song.domain.Song;
+import shook.shook.song.domain.killingpart.KillingPart;
+import shook.shook.song.exception.SongDataFileReadException;
+
+@Component
+public class SongDataExcelReader {
+
+    private static final int VIDEO_ID_INDEX = 1;
+    private static final int FIRST_PAGE_INDEX = 0;
+    private static final int SONG_LENGTH_INDEX = 1;
+    private static final int START_SECOND_INDEX = 0;
+
+    private final String videoUrlDelimiter;
+    private final String killingpartDataDelimiter;
+    private final String songLengthSuffix;
+
+    public SongDataExcelReader(
+        @Value("${excel.video-url-delimiter}") final String videoUrlDelimiter,
+        @Value("${excel.killingpart-data-delimiter}") final String killingpartDataDelimiter,
+        @Value("${excel.song-length-suffix}") final String songLengthSuffix
+    ) {
+        this.videoUrlDelimiter = videoUrlDelimiter;
+        this.killingpartDataDelimiter = killingpartDataDelimiter;
+        this.songLengthSuffix = songLengthSuffix;
+    }
+
+    public List<Song> parseToSongs(final MultipartFile excel) {
+        final List<Song> songs = new ArrayList<>();
+        try (
+            final InputStream inputStream = excel.getInputStream();
+            final XSSFWorkbook workbook = new XSSFWorkbook(inputStream)
+        ) {
+            final XSSFSheet sheet = workbook.getSheetAt(FIRST_PAGE_INDEX);
+            final Iterator<Row> sheetIterator = sheet.iterator();
+
+            passColumnNameRow(sheetIterator);
+            sheetIterator.forEachRemaining(row -> {
+                final Optional<Song> song = parseToSong(row);
+                song.ifPresent(songs::add);
+            });
+        } catch (IOException e) {
+            throw new SongDataFileReadException();
+        }
+        return songs;
+    }
+
+    private void passColumnNameRow(final Iterator<Row> iterator) {
+        if (iterator.hasNext()) {
+            iterator.next();
+        }
+    }
+
+    private Optional<Song> parseToSong(final Row currentRow) {
+        final Iterator<Cell> cellIterator = currentRow.iterator();
+
+        final String title = getString(cellIterator);
+        final String singer = getString(cellIterator);
+        final String albumCoverUrl = getString(cellIterator);
+        final int length = getIntegerCell(cellIterator);
+        final String videoUrl = getString(cellIterator);
+
+        if (isNotValidData(title, singer, albumCoverUrl, length, videoUrl)) {
+            return Optional.empty();
+        }
+
+        final String videoId = videoUrl.split(videoUrlDelimiter)[VIDEO_ID_INDEX];
+        final Optional<KillingParts> killingParts = getKillingParts(cellIterator);
+
+        return killingParts.map(
+            parts -> new Song(title, videoId, albumCoverUrl, singer, length, parts));
+    }
+
+    private String getString(final Iterator<Cell> iterator) {
+        return iterator.next().getStringCellValue().trim();
+    }
+
+    private int getIntegerCell(final Iterator<Cell> iterator) {
+        return (int) iterator.next().getNumericCellValue();
+    }
+
+    private boolean isNotValidData(
+        final String title,
+        final String singer,
+        final String albumCoverUrl,
+        final int length,
+        final String videoUrl
+    ) {
+        return title.isEmpty() ||
+            singer.isEmpty() ||
+            albumCoverUrl.isEmpty() ||
+            videoUrl.isEmpty() || !videoUrl.contains(videoUrlDelimiter) ||
+            length == 0;
+    }
+
+    private Optional<KillingParts> getKillingParts(final Iterator<Cell> cellIterator) {
+        final Optional<KillingPart> first = toKillingPart(getString(cellIterator));
+        final Optional<KillingPart> second = toKillingPart(getString(cellIterator));
+        final Optional<KillingPart> third = toKillingPart(getString(cellIterator));
+
+        if (first.isEmpty() || second.isEmpty() || third.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new KillingParts(List.of(first.get(), second.get(), third.get())));
+    }
+
+    private Optional<KillingPart> toKillingPart(final String killingPart) {
+        final String[] killingPartDataElements = killingPart.split(killingpartDataDelimiter);
+        if (killingPartDataElements.length != 2) {
+            return Optional.empty();
+        }
+
+        final int start = Integer.parseInt(killingPartDataElements[START_SECOND_INDEX].strip());
+        final String songLength = killingPartDataElements[SONG_LENGTH_INDEX].strip();
+        if (!songLength.endsWith(songLengthSuffix)) {
+            return Optional.empty();
+        }
+        final int length = Integer.parseInt(songLength.split(songLengthSuffix)[0]);
+
+        return Optional.of(KillingPart.forSave(start, PartLength.findBySecond(length)));
+    }
+}

--- a/backend/src/main/java/shook/shook/song/application/SongService.java
+++ b/backend/src/main/java/shook/shook/song/application/SongService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import shook.shook.auth.ui.Authority;
 import shook.shook.auth.ui.argumentresolver.MemberInfo;
 import shook.shook.member.domain.Member;
@@ -18,6 +19,7 @@ import shook.shook.song.application.dto.SongSwipeResponse;
 import shook.shook.song.application.dto.SongWithKillingPartsRegisterRequest;
 import shook.shook.song.application.killingpart.dto.HighLikedSongResponse;
 import shook.shook.song.domain.Song;
+import shook.shook.song.domain.SongTitle;
 import shook.shook.song.domain.killingpart.repository.KillingPartRepository;
 import shook.shook.song.domain.repository.SongRepository;
 import shook.shook.song.domain.repository.dto.SongTotalLikeCountDto;
@@ -34,12 +36,15 @@ public class SongService {
     private final SongRepository songRepository;
     private final KillingPartRepository killingPartRepository;
     private final MemberRepository memberRepository;
+    private final SongDataExcelReader songDataExcelReader;
 
     @Transactional
     public Long register(final SongWithKillingPartsRegisterRequest request) {
         final Song song = request.convertToSong();
+        if (songRepository.existsSongByTitle(new SongTitle(song.getTitle()))) {
+            throw new SongException.SongAlreadyExistException();
+        }
         final Song savedSong = songRepository.save(song);
-
         killingPartRepository.saveAll(song.getKillingParts());
 
         return savedSong.getId();
@@ -151,7 +156,7 @@ public class SongService {
         final Member member = findMemberById(memberInfo.getMemberId());
 
         return songs.stream()
-            .map((song) -> SongResponse.of(song, member))
+            .map(song -> SongResponse.of(song, member))
             .toList();
     }
 
@@ -165,5 +170,15 @@ public class SongService {
             findAfterSongs(currentSong);
 
         return convertToSongResponses(memberInfo, afterSongs);
+    }
+
+    @Transactional
+    public void saveSongsFromExcelFile(final MultipartFile excel) {
+        final List<Song> songs = songDataExcelReader.parseToSongs(excel);
+
+        songRepository.saveAll(songs);
+        for (Song song : songs) {
+            killingPartRepository.saveAll(song.getKillingParts());
+        }
     }
 }

--- a/backend/src/main/java/shook/shook/song/application/SongService.java
+++ b/backend/src/main/java/shook/shook/song/application/SongService.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -46,8 +47,10 @@ public class SongService {
     }
 
     private Song saveSong(final Song song) {
-        if (songRepository.existsSongByTitle(new SongTitle(song.getTitle()))) {
-            throw new SongException.SongAlreadyExistException(Map.of("Song-Name", song.getTitle()));
+        final Optional<Song> findSong =
+            songRepository.findSongByTitle(new SongTitle(song.getTitle()));
+        if (findSong.isPresent()) {
+            return findSong.get();
         }
         final Song savedSong = songRepository.save(song);
         killingPartRepository.saveAll(song.getKillingParts());

--- a/backend/src/main/java/shook/shook/song/domain/repository/SongRepository.java
+++ b/backend/src/main/java/shook/shook/song/domain/repository/SongRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import shook.shook.song.domain.Song;
+import shook.shook.song.domain.SongTitle;
 import shook.shook.song.domain.repository.dto.SongTotalLikeCountDto;
 
 @Repository
@@ -38,4 +39,6 @@ public interface SongRepository extends JpaRepository<Song, Long> {
         @Param("id") final Long songId,
         final Pageable pageable
     );
+    
+    boolean existsSongByTitle(final SongTitle title);
 }

--- a/backend/src/main/java/shook/shook/song/domain/repository/SongRepository.java
+++ b/backend/src/main/java/shook/shook/song/domain/repository/SongRepository.java
@@ -1,6 +1,7 @@
 package shook.shook.song.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -39,6 +40,6 @@ public interface SongRepository extends JpaRepository<Song, Long> {
         @Param("id") final Long songId,
         final Pageable pageable
     );
-    
-    boolean existsSongByTitle(final SongTitle title);
+
+    Optional<Song> findSongByTitle(final SongTitle title);
 }

--- a/backend/src/main/java/shook/shook/song/exception/SongDataFileReadException.java
+++ b/backend/src/main/java/shook/shook/song/exception/SongDataFileReadException.java
@@ -1,0 +1,16 @@
+package shook.shook.song.exception;
+
+import java.util.Map;
+import shook.shook.globalexception.CustomException;
+import shook.shook.globalexception.ErrorCode;
+
+public class SongDataFileReadException extends CustomException {
+
+    public SongDataFileReadException() {
+        super(ErrorCode.CAN_NOT_READ_SONG_DATA_FILE);
+    }
+
+    public SongDataFileReadException(final Map<String, String> inputValuesByProperty) {
+        super(ErrorCode.CAN_NOT_READ_SONG_DATA_FILE, inputValuesByProperty);
+    }
+}

--- a/backend/src/main/java/shook/shook/song/exception/SongException.java
+++ b/backend/src/main/java/shook/shook/song/exception/SongException.java
@@ -126,4 +126,15 @@ public class SongException extends CustomException {
             super(ErrorCode.TOO_LONG_SINGER_NAME, inputValuesByProperty);
         }
     }
+
+    public static class SongAlreadyExistException extends SongException {
+
+        public SongAlreadyExistException() {
+            super(ErrorCode.SONG_ALREADY_EXIST);
+        }
+
+        public SongAlreadyExistException(final Map<String, String> inputValuesByProperty) {
+            super(ErrorCode.SONG_ALREADY_EXIST, inputValuesByProperty);
+        }
+    }
 }

--- a/backend/src/main/java/shook/shook/song/ui/AdminSongController.java
+++ b/backend/src/main/java/shook/shook/song/ui/AdminSongController.java
@@ -1,8 +1,8 @@
 package shook.shook.song.ui;
 
 import jakarta.validation.Valid;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,9 +25,9 @@ public class AdminSongController implements AdminSongApi {
     public ResponseEntity<Void> registerSongWithKillingParts(
         @Valid @RequestBody final SongWithKillingPartsRegisterRequest request
     ) {
-        songService.register(request);
+        final Long registeredSongId = songService.register(request);
 
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.created(URI.create("/songs/" + registeredSongId)).build();
     }
 
     @PostMapping("/file")

--- a/backend/src/main/java/shook/shook/song/ui/AdminSongController.java
+++ b/backend/src/main/java/shook/shook/song/ui/AdminSongController.java
@@ -7,7 +7,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import shook.shook.song.application.SongService;
 import shook.shook.song.application.dto.SongWithKillingPartsRegisterRequest;
 import shook.shook.song.ui.openapi.AdminSongApi;
@@ -26,5 +28,14 @@ public class AdminSongController implements AdminSongApi {
         songService.register(request);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/file")
+    public ResponseEntity<Void> registerSongWithExcelFile(
+        @RequestParam("file") MultipartFile excelFile
+    ) {
+        songService.saveSongsFromExcelFile(excelFile);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -35,3 +35,8 @@ jwt:
 
 cookie:
   valid-time: 634000
+
+excel:
+  video-url-delimiter: "="
+  killingpart-data-delimiter: " "
+  song-length-suffix: "s"

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -23,7 +23,6 @@ spring:
     init:
       mode: always
       schema-locations: classpath:schema.sql
-      data-locations: classpath:dev/data.sql
 
   jpa:
     properties:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -54,3 +54,8 @@ jwt:
 # Properties Only For Local
 cookie:
   valid-time: 634000
+
+excel:
+  video-url-delimiter: "v="
+  killingpart-data-delimiter: " "
+  song-length-suffix: "초"

--- a/backend/src/test/java/shook/shook/song/application/SongServiceTest.java
+++ b/backend/src/test/java/shook/shook/song/application/SongServiceTest.java
@@ -43,10 +43,6 @@ class SongServiceTest extends UsingJpaTest {
 
     @Autowired
     private MemberRepository memberRepository;
-
-    @Autowired
-    private SongDataExcelReader songDataExcelReader;
-
     private SongService songService;
 
     @BeforeEach
@@ -55,7 +51,7 @@ class SongServiceTest extends UsingJpaTest {
             songRepository,
             killingPartRepository,
             memberRepository,
-            songDataExcelReader
+            new SongDataExcelReader(" ", " ", " ")
         );
     }
 
@@ -95,7 +91,7 @@ class SongServiceTest extends UsingJpaTest {
     void findById_exist_login_member() {
         //given
         final Member member = createAndSaveMember("email@naver.com", "email");
-        final Song song = registerNewSong();
+        final Song song = registerNewSong("title");
         addLikeToEachKillingParts(song, member);
 
         //when
@@ -132,7 +128,7 @@ class SongServiceTest extends UsingJpaTest {
     @Test
     void findById_exist_not_login_member() {
         //given
-        final Song song = registerNewSong();
+        final Song song = registerNewSong("title");
 
         //when
         saveAndClearEntityManager();
@@ -182,10 +178,10 @@ class SongServiceTest extends UsingJpaTest {
     @Test
     void showHighLikedSongs() {
         // given
-        final Song firstSong = registerNewSong();
-        final Song secondSong = registerNewSong();
-        final Song thirdSong = registerNewSong();
-        final Song fourthSong = registerNewSong();
+        final Song firstSong = registerNewSong("title1");
+        final Song secondSong = registerNewSong("title2");
+        final Song thirdSong = registerNewSong("title3");
+        final Song fourthSong = registerNewSong("title4");
 
         final Member member1 = createAndSaveMember("first@naver.com", "first");
         final Member member2 = createAndSaveMember("second@naver.com", "second");
@@ -218,9 +214,9 @@ class SongServiceTest extends UsingJpaTest {
         );
     }
 
-    private Song registerNewSong() {
+    private Song registerNewSong(final String title) {
         final SongWithKillingPartsRegisterRequest request = new SongWithKillingPartsRegisterRequest(
-            "title", "elevenVideo", "imageUrl", "singer", 300,
+            title, "elevenVideo", "imageUrl", "singer", 300,
             List.of(
                 new KillingPartRegisterRequest(10, 5),
                 new KillingPartRegisterRequest(15, 10),
@@ -254,11 +250,11 @@ class SongServiceTest extends UsingJpaTest {
         @Test
         void firstFindByMember() {
             // given
-            final Song firstSong = registerNewSong();
-            final Song secondSong = registerNewSong();
-            final Song thirdSong = registerNewSong();
-            final Song fourthSong = registerNewSong();
-            final Song fifthSong = registerNewSong();
+            final Song firstSong = registerNewSong("title1");
+            final Song secondSong = registerNewSong("title2");
+            final Song thirdSong = registerNewSong("title3");
+            final Song fourthSong = registerNewSong("title4");
+            final Song fifthSong = registerNewSong("title5");
 
             final Member member = createAndSaveMember("first@naver.com", "first");
 
@@ -313,11 +309,11 @@ class SongServiceTest extends UsingJpaTest {
         @Test
         void findSongByIdForBeforeSwipe() {
             // given
-            final Song firstSong = registerNewSong();
-            final Song secondSong = registerNewSong();
-            final Song standardSong = registerNewSong();
-            final Song fourthSong = registerNewSong();
-            final Song fifthSong = registerNewSong();
+            final Song firstSong = registerNewSong("title1");
+            final Song secondSong = registerNewSong("title2");
+            final Song standardSong = registerNewSong("title3");
+            final Song fourthSong = registerNewSong("title4");
+            final Song fifthSong = registerNewSong("title5");
 
             final Member member = createAndSaveMember("first@naver.com", "first");
             final Member member2 = createAndSaveMember("first@naver.com", "first");
@@ -346,11 +342,11 @@ class SongServiceTest extends UsingJpaTest {
         @Test
         void findSongByIdForAfterSwipe() {
             // given
-            final Song firstSong = registerNewSong();
-            final Song secondSong = registerNewSong();
-            final Song thirdSong = registerNewSong();
-            final Song standardSong = registerNewSong();
-            final Song fifthSong = registerNewSong();
+            final Song firstSong = registerNewSong("title1");
+            final Song secondSong = registerNewSong("title2");
+            final Song thirdSong = registerNewSong("title3");
+            final Song standardSong = registerNewSong("title4");
+            final Song fifthSong = registerNewSong("title5");
 
             final Member member = createAndSaveMember("first@naver.com", "first");
             final Member member2 = createAndSaveMember("first@naver.com", "first");

--- a/backend/src/test/java/shook/shook/song/application/SongServiceTest.java
+++ b/backend/src/test/java/shook/shook/song/application/SongServiceTest.java
@@ -44,11 +44,19 @@ class SongServiceTest extends UsingJpaTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private SongDataExcelReader songDataExcelReader;
+
     private SongService songService;
 
     @BeforeEach
     public void setUp() {
-        songService = new SongService(songRepository, killingPartRepository, memberRepository);
+        songService = new SongService(
+            songRepository,
+            killingPartRepository,
+            memberRepository,
+            songDataExcelReader
+        );
     }
 
     @DisplayName("Song 을 저장할 때, Song 과 KillingParts 가 함께 저장된다.")

--- a/backend/src/test/java/shook/shook/song/ui/AdminSongControllerTest.java
+++ b/backend/src/test/java/shook/shook/song/ui/AdminSongControllerTest.java
@@ -74,6 +74,6 @@ class AdminSongControllerTest {
             .when().log().all()
             .post("/songs")
             .then().log().all()
-            .statusCode(HttpStatus.BAD_REQUEST.value());
+            .statusCode(HttpStatus.CREATED.value());
     }
 }

--- a/backend/src/test/java/shook/shook/song/ui/AdminSongControllerTest.java
+++ b/backend/src/test/java/shook/shook/song/ui/AdminSongControllerTest.java
@@ -6,10 +6,12 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import shook.shook.song.application.SongService;
 import shook.shook.song.application.dto.KillingPartRegisterRequest;
 import shook.shook.song.application.dto.SongWithKillingPartsRegisterRequest;
 
@@ -18,6 +20,9 @@ class AdminSongControllerTest {
 
     @LocalServerPort
     public int port;
+
+    @Autowired
+    private SongService songService;
 
     @BeforeEach
     void setUp() {
@@ -29,7 +34,7 @@ class AdminSongControllerTest {
     void register_success() {
         // given
         final SongWithKillingPartsRegisterRequest request = new SongWithKillingPartsRegisterRequest(
-            "title", "elevenVideo", "imageUrl", "singer", 300,
+            "title1", "elevenVideo", "imageUrl", "singer", 300,
             List.of(
                 new KillingPartRegisterRequest(10, 5),
                 new KillingPartRegisterRequest(15, 10),
@@ -45,5 +50,30 @@ class AdminSongControllerTest {
             .post("/songs")
             .then().log().all()
             .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @DisplayName("노래와 킬링파트 등록시 이미 존재하는 노래일 경우 401 상태코드를 반환한다.")
+    @Test
+    void register_alreadyExist() {
+        // given
+        final SongWithKillingPartsRegisterRequest request = new SongWithKillingPartsRegisterRequest(
+            "title2", "elevenVideo", "imageUrl", "singer", 300,
+            List.of(
+                new KillingPartRegisterRequest(10, 5),
+                new KillingPartRegisterRequest(15, 10),
+                new KillingPartRegisterRequest(0, 10)
+            )
+        );
+
+        songService.register(request);
+
+        // when, then
+        RestAssured.given().log().all()
+            .contentType(ContentType.JSON)
+            .body(request)
+            .when().log().all()
+            .post("/songs")
+            .then().log().all()
+            .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 }


### PR DESCRIPTION
기본 한곡 추가 api 에 노래 중복 검증 추가
불필요한 괄호 삭제

## 📝작업 내용

- 엑셀 파일을 통해 노래 데이터 등록 API 구현
  - 특정 포맷에 대해서는 다른 곳에서 공유하겠습니다. 
- 기본 한곡 추가 api 에 노래 중복 검증 추가
- 불필요한 괄호 삭제

참고사항

이번 이벤트까지 사용하기 위해 기한을 맞추려고 테스트코드는 우선 생략하였습니다.

## #️⃣연관된 이슈

close #388 


