### PR TITLE
Refactor/#408 SongDetailListPage의 Youtube Player 스크립트 로딩 성능 개선

### DIFF
--- a/frontend/src/pages/SongDetailListPage.tsx
+++ b/frontend/src/pages/SongDetailListPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { styled } from 'styled-components';
 import SongDetailItem from '@/features/songs/components/SongDetailItem';
@@ -64,7 +64,7 @@ const SongDetailListPage = () => {
     return () => nextObserver.disconnect();
   }, [fetchExtraNextSongDetails, songDetailEntries]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     itemRef.current?.scrollIntoView({ behavior: 'instant', block: 'start' });
   }, [songDetailEntries]);
 


### PR DESCRIPTION
## 📝작업 내용

[youtube player 생성 시점을 intersection observer로 제어 하도록 개선](https://github.com/woowacourse-teams/2023-shook/commit/5e4a5a68513f308221c42ec96085ef511745359a)
[paint 전 단계에 스크롤 이동 하도록 개선](https://github.com/woowacourse-teams/2023-shook/commit/ff8f27f2dc806275146ce602d36359f5430a0ea9)

## 💬리뷰 참고사항

### player 스크립트 로드 제어 성공

#### **그리고....캐싱 성공!!?!??!🤪🤪🤪🤪**

![image](https://github.com/woowacourse-teams/2023-shook/assets/77152650/31c65046-ac58-435f-9de2-044650a35ffa)

스크립트 로드를 제어하여 1개의 player를 구성하는데 필요한 3개의 js파일을 로드하면서,
이후 요청에 대한 **캐시까지 적용되는 모습입니다.**

기존에는 21개의 player를 병렬적으로 한번에 로드했기 때문에, 
중복되는 스크립트임에도 각 요청시 캐시된 스크립트가 없어, **63개의 js파일을 불러오는 대참사가 발생했던 거죠.😅**
저희 모두에게 좋은 경험이 된 것 같네요.

### 코드에 대한 설명

커밋 메세지 바디에 상세 설명 적어놓았습니다.
callbackRef, observer ref 생성 이유, layoutEffect 사용 이유에 대한 설명이 더 필요하시면 바로 말해주세요~ 
대화로 설명 드리겠습니다~😀


## #️⃣연관된 이슈

close #408 


