### PR TITLE
Feat/#420 Song 도메인에 Genre 필드 추가

### DIFF
--- a/backend/src/main/java/shook/shook/song/application/SongDataExcelReader.java
+++ b/backend/src/main/java/shook/shook/song/application/SongDataExcelReader.java
@@ -109,11 +109,11 @@ public class SongDataExcelReader {
         final int length,
         final String videoUrl
     ) {
-        return title.isEmpty() ||
-            singer.isEmpty() ||
-            albumCoverUrl.isEmpty() ||
-            genre.isEmpty() ||
-            videoUrl.isEmpty() || !videoUrl.contains(videoUrlDelimiter) ||
+        return title.isBlank() ||
+            singer.isBlank() ||
+            albumCoverUrl.isBlank() ||
+            genre.isBlank() ||
+            videoUrl.isBlank() || !videoUrl.contains(videoUrlDelimiter) ||
             length == 0;
     }
 

--- a/backend/src/main/java/shook/shook/song/application/SongDataExcelReader.java
+++ b/backend/src/main/java/shook/shook/song/application/SongDataExcelReader.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import shook.shook.part.domain.PartLength;
+import shook.shook.song.domain.Genre;
 import shook.shook.song.domain.KillingParts;
 import shook.shook.song.domain.Song;
 import shook.shook.song.domain.killingpart.KillingPart;
@@ -60,7 +61,7 @@ public class SongDataExcelReader {
             throw new SongDataFileReadException();
         }
         Collections.reverse(songs);
-        
+
         return songs;
     }
 
@@ -76,10 +77,11 @@ public class SongDataExcelReader {
         final String title = getString(cellIterator);
         final String singer = getString(cellIterator);
         final String albumCoverUrl = getString(cellIterator);
+        final String genre = getString(cellIterator);
         final int length = getIntegerCell(cellIterator);
         final String videoUrl = getString(cellIterator);
 
-        if (isNotValidData(title, singer, albumCoverUrl, length, videoUrl)) {
+        if (isNotValidData(title, singer, albumCoverUrl, genre, length, videoUrl)) {
             return Optional.empty();
         }
 
@@ -87,7 +89,8 @@ public class SongDataExcelReader {
         final Optional<KillingParts> killingParts = getKillingParts(cellIterator);
 
         return killingParts.map(
-            parts -> new Song(title, videoId, albumCoverUrl, singer, length, parts));
+            parts -> new Song(title, videoId, albumCoverUrl, singer, length, Genre.from(genre),
+                parts));
     }
 
     private String getString(final Iterator<Cell> iterator) {
@@ -102,12 +105,14 @@ public class SongDataExcelReader {
         final String title,
         final String singer,
         final String albumCoverUrl,
+        final String genre,
         final int length,
         final String videoUrl
     ) {
         return title.isEmpty() ||
             singer.isEmpty() ||
             albumCoverUrl.isEmpty() ||
+            genre.isEmpty() ||
             videoUrl.isEmpty() || !videoUrl.contains(videoUrlDelimiter) ||
             length == 0;
     }

--- a/backend/src/main/java/shook/shook/song/application/dto/SongWithKillingPartsRegisterRequest.java
+++ b/backend/src/main/java/shook/shook/song/application/dto/SongWithKillingPartsRegisterRequest.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import shook.shook.song.domain.Genre;
 import shook.shook.song.domain.KillingParts;
 import shook.shook.song.domain.Song;
 
@@ -40,12 +41,17 @@ public class SongWithKillingPartsRegisterRequest {
     @Positive
     private Integer length;
 
+    @Schema(description = "노래 장르", example = "댄스")
+    @NotBlank
+    private String genre;
+
     @Schema(description = "킬링파트 3개")
     @NotEmpty
     private List<KillingPartRegisterRequest> killingParts;
 
     public Song convertToSong() {
-        return new Song(title, videoId, imageUrl, singer, length, convertToKillingParts());
+        return new Song(title, videoId, imageUrl, singer, length, Genre.from(genre),
+            convertToKillingParts());
     }
 
     private KillingParts convertToKillingParts() {

--- a/backend/src/main/java/shook/shook/song/domain/Genre.java
+++ b/backend/src/main/java/shook/shook/song/domain/Genre.java
@@ -27,7 +27,7 @@ public enum Genre {
 
     public static Genre from(final String name) {
         return Arrays.stream(values())
-            .filter(value -> value.getValue().equalsIgnoreCase(name))
+            .filter(genre -> genre.value.equalsIgnoreCase(name))
             .findFirst()
             .orElse(ETC);
     }

--- a/backend/src/main/java/shook/shook/song/domain/Genre.java
+++ b/backend/src/main/java/shook/shook/song/domain/Genre.java
@@ -1,0 +1,38 @@
+package shook.shook.song.domain;
+
+import java.util.Arrays;
+
+public enum Genre {
+
+    BALLAD("발라드"),
+    DANCE("댄스"),
+    HIPHOP("힙합"),
+    RHYTHM_AND_BLUES("R&B/Soul"),
+    INDIE("인디"),
+    ROCK_METAL("록/메탈"),
+    TROT("트로트"),
+    FOLK_BLUES("포크/블루스"),
+    POP("팝"),
+    JAZZ("재즈"),
+    CLASSIC("클래식"),
+    J_POP("JPOP"),
+    EDM("EDM"),
+    ETC("기타");
+
+    private final String value;
+
+    Genre(final String value) {
+        this.value = value;
+    }
+
+    public static Genre from(final String name) {
+        return Arrays.stream(values())
+            .filter(value -> value.getValue().equalsIgnoreCase(name))
+            .findFirst()
+            .orElse(ETC);
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/backend/src/main/java/shook/shook/song/domain/Song.java
+++ b/backend/src/main/java/shook/shook/song/domain/Song.java
@@ -3,6 +3,8 @@ package shook.shook.song.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -43,6 +45,10 @@ public class Song {
     @Embedded
     private SongLength length;
 
+    @Column(nullable = true, updatable = false)
+    @Enumerated(EnumType.STRING)
+    private Genre genre;
+
     @Embedded
     private KillingParts killingParts = new KillingParts();
 
@@ -61,6 +67,7 @@ public class Song {
         final String imageUrl,
         final String singer,
         final int length,
+        final Genre genre,
         final KillingParts killingParts
     ) {
         validate(killingParts);
@@ -70,6 +77,7 @@ public class Song {
         this.albumCoverUrl = new AlbumCoverUrl(imageUrl);
         this.singer = new Singer(singer);
         this.length = new SongLength(length);
+        this.genre = genre;
         killingParts.setSong(this);
         this.killingParts = killingParts;
     }
@@ -80,9 +88,10 @@ public class Song {
         final String albumCoverUrl,
         final String singer,
         final int length,
+        final Genre genre,
         final KillingParts killingParts
     ) {
-        this(null, title, videoId, albumCoverUrl, singer, length, killingParts);
+        this(null, title, videoId, albumCoverUrl, singer, length, genre, killingParts);
     }
 
     private void validate(final KillingParts killingParts) {

--- a/backend/src/main/resources/dev/schema.sql
+++ b/backend/src/main/resources/dev/schema.sql
@@ -14,6 +14,7 @@ create table if not exists song
     length          integer      not null,
     video_id        varchar(20)  not null,
     album_cover_url text         not null,
+    genre           varchar(20),
     created_at      timestamp(6) not null,
     primary key (id)
 );

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -88,3 +88,4 @@ alter table killing_part
     alter column like_count set default 0;
 alter table member
     add column created_at timestamp(6) not null;
+alter table song add column genre varchar(20);

--- a/backend/src/test/java/shook/shook/song/application/SongServiceTest.java
+++ b/backend/src/test/java/shook/shook/song/application/SongServiceTest.java
@@ -60,7 +60,7 @@ class SongServiceTest extends UsingJpaTest {
     void register() {
         // given
         final SongWithKillingPartsRegisterRequest request = new SongWithKillingPartsRegisterRequest(
-            "title", "elevenVideo", "imageUrl", "singer", 300,
+            "title", "elevenVideo", "imageUrl", "singer", 300, "댄스",
             List.of(
                 new KillingPartRegisterRequest(10, 5),
                 new KillingPartRegisterRequest(15, 10),
@@ -216,7 +216,7 @@ class SongServiceTest extends UsingJpaTest {
 
     private Song registerNewSong(final String title) {
         final SongWithKillingPartsRegisterRequest request = new SongWithKillingPartsRegisterRequest(
-            title, "elevenVideo", "imageUrl", "singer", 300,
+            title, "elevenVideo", "imageUrl", "singer", 300, "댄스",
             List.of(
                 new KillingPartRegisterRequest(10, 5),
                 new KillingPartRegisterRequest(15, 10),

--- a/backend/src/test/java/shook/shook/song/domain/GenreTest.java
+++ b/backend/src/test/java/shook/shook/song/domain/GenreTest.java
@@ -1,0 +1,31 @@
+package shook.shook.song.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GenreTest {
+
+    @DisplayName("입력값에 따른 장르를 찾는다.")
+    @Test
+    void from() {
+        // given
+        // when
+        final Genre genre = Genre.from("댄스");
+
+        // then
+        assertThat(genre).isEqualTo(Genre.DANCE);
+    }
+
+    @DisplayName("입력값에 맞는 장르가 없다면 ETC 가 반환된다.")
+    @Test
+    void from_notFound_ETC() {
+        // given
+        // when
+        final Genre genre = Genre.from("하이");
+
+        // then
+        assertThat(genre).isEqualTo(Genre.ETC);
+    }
+}

--- a/backend/src/test/java/shook/shook/song/domain/SongTest.java
+++ b/backend/src/test/java/shook/shook/song/domain/SongTest.java
@@ -17,7 +17,8 @@ class SongTest {
     void songCreate_nullKillingParts_fail() {
         // given
         // when, then
-        assertThatThrownBy(() -> new Song("title", "videoId", "imageUrl", "singer", 300, null))
+        assertThatThrownBy(
+            () -> new Song("title", "videoId", "imageUrl", "singer", 300, Genre.from("댄스"), null))
             .isInstanceOf(KillingPartsException.EmptyKillingPartsException.class);
     }
 
@@ -32,6 +33,7 @@ class SongTest {
             List.of(killingPart1, killingPart2, killingPart3)
         );
         final Song song = new Song("title", "3rUPND6FG8A", "image_url", "singer", 230,
+            Genre.from("댄스"),
             killingParts);
 
         // when

--- a/backend/src/test/java/shook/shook/song/domain/killingpart/KillingPartTest.java
+++ b/backend/src/test/java/shook/shook/song/domain/killingpart/KillingPartTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import shook.shook.member.domain.Member;
 import shook.shook.part.domain.PartLength;
+import shook.shook.song.domain.Genre;
 import shook.shook.song.domain.KillingParts;
 import shook.shook.song.domain.Song;
 import shook.shook.song.exception.SongException;
@@ -141,6 +142,7 @@ class KillingPartTest {
             final KillingPart dummyKillingPart2 = KillingPart.forSave(0, PartLength.SHORT);
             final KillingPart dummyKillingPart3 = KillingPart.forSave(0, PartLength.LONG);
             final Song song = new Song("title", "elevenVideo", "imageUrl", "singer", 10,
+                Genre.from("댄스"),
                 new KillingParts(List.of(dummyKillingPart1, dummyKillingPart2, dummyKillingPart3))
             );
 
@@ -164,7 +166,7 @@ class KillingPartTest {
             final KillingPart killingPart = KillingPart.saved(1L, 10, PartLength.SHORT, EMPTY_SONG);
 
             // then
-            assertThat(killingPart.getLikeCount()).isEqualTo(0);
+            assertThat(killingPart.getLikeCount()).isZero();
             assertThat(killingPart.getKillingPartLikes()).isEmpty();
         }
 
@@ -215,7 +217,7 @@ class KillingPartTest {
 
             // then
             assertThat(killingPart.getKillingPartLikes()).isEmpty();
-            assertThat(killingPart.getLikeCount()).isEqualTo(0);
+            assertThat(killingPart.getLikeCount()).isZero();
         }
 
         @DisplayName("킬링파트에 좋아요를 취소할 때, 존재하지 않았다면 likeCount 가 감소하지 않는다.")

--- a/backend/src/test/java/shook/shook/song/domain/killingpart/repository/KillingPartRepositoryTest.java
+++ b/backend/src/test/java/shook/shook/song/domain/killingpart/repository/KillingPartRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import shook.shook.part.domain.PartLength;
+import shook.shook.song.domain.Genre;
 import shook.shook.song.domain.KillingParts;
 import shook.shook.song.domain.Song;
 import shook.shook.song.domain.killingpart.KillingPart;
@@ -43,7 +44,7 @@ class KillingPartRepositoryTest extends UsingJpaTest {
             )
         );
         SAVED_SONG = songRepository.save(
-            new Song("제목", "비디오ID는 11글자", "이미지URL", "가수", 30, KILLING_PARTS));
+            new Song("제목", "비디오ID는 11글자", "이미지URL", "가수", 30, Genre.from("댄스"), KILLING_PARTS));
     }
 
     @DisplayName("KillingPart 를 모두 저장한다.")

--- a/backend/src/test/java/shook/shook/song/domain/repository/SongRepositoryTest.java
+++ b/backend/src/test/java/shook/shook/song/domain/repository/SongRepositoryTest.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.PageRequest;
 import shook.shook.member.domain.Member;
 import shook.shook.member.domain.repository.MemberRepository;
 import shook.shook.part.domain.PartLength;
+import shook.shook.song.domain.Genre;
 import shook.shook.song.domain.KillingParts;
 import shook.shook.song.domain.Song;
 import shook.shook.song.domain.killingpart.KillingPart;
@@ -42,7 +43,7 @@ class SongRepositoryTest extends UsingJpaTest {
         final KillingPart thirdKillingPart = KillingPart.forSave(20, PartLength.SHORT);
 
         return new Song(
-            "제목", "비디오ID는 11글자", "이미지URL", "가수", 5,
+            "제목", "비디오ID는 11글자", "이미지URL", "가수", 5, Genre.from("댄스"),
             new KillingParts(List.of(firstKillingPart, secondKillingPart, thirdKillingPart)));
     }
 

--- a/backend/src/test/java/shook/shook/song/ui/AdminSongControllerTest.java
+++ b/backend/src/test/java/shook/shook/song/ui/AdminSongControllerTest.java
@@ -34,7 +34,7 @@ class AdminSongControllerTest {
     void register_success() {
         // given
         final SongWithKillingPartsRegisterRequest request = new SongWithKillingPartsRegisterRequest(
-            "title1", "elevenVideo", "imageUrl", "singer", 300,
+            "title1", "elevenVideo", "imageUrl", "singer", 300, "댄스",
             List.of(
                 new KillingPartRegisterRequest(10, 5),
                 new KillingPartRegisterRequest(15, 10),
@@ -57,7 +57,7 @@ class AdminSongControllerTest {
     void register_alreadyExist() {
         // given
         final SongWithKillingPartsRegisterRequest request = new SongWithKillingPartsRegisterRequest(
-            "title2", "elevenVideo", "imageUrl", "singer", 300,
+            "title2", "elevenVideo", "imageUrl", "singer", 300, "댄스",
             List.of(
                 new KillingPartRegisterRequest(10, 5),
                 new KillingPartRegisterRequest(15, 10),

--- a/backend/src/test/resources/killingpart/initialize_killing_part_song.sql
+++ b/backend/src/test/resources/killingpart/initialize_killing_part_song.sql
@@ -12,6 +12,7 @@ create table if not exists song
     length          integer      not null,
     video_id        varchar(20)  not null,
     album_cover_url text         not null,
+    genre           varchar(20),
     created_at      timestamp(6) not null,
     primary key (id)
 );

--- a/backend/src/test/resources/schema-test.sql
+++ b/backend/src/test/resources/schema-test.sql
@@ -15,7 +15,7 @@ create table if not exists song
     length          integer      not null,
     video_id        varchar(20)  not null,
     album_cover_url text         not null,
-    genre           varchar(20) not null,
+    genre           varchar(20),
     created_at      timestamp(6) not null,
     primary key (id)
 );

--- a/backend/src/test/resources/schema-test.sql
+++ b/backend/src/test/resources/schema-test.sql
@@ -15,6 +15,7 @@ create table if not exists song
     length          integer      not null,
     video_id        varchar(20)  not null,
     album_cover_url text         not null,
+    genre           varchar(20) not null,
     created_at      timestamp(6) not null,
     primary key (id)
 );


### PR DESCRIPTION
## 📝작업 내용

Song 도메인에 Genre 필드 추가

## 💬리뷰 참고사항

- 우선은 장르 데이터가 없는 이전 노래들을 위해 Genre를 nullable 로 설정했습니다.
- 이 부분은 운영 서버 데이터의 노래들에 장르가 모두 추가되면 schema.sql 을 모두 nullable=false 로 설정하겠습니다.

## #️⃣연관된 이슈

closes #420 

