### PR TITLE
Feat/#385 토큰을 관리하는 방식 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 
     //log to slack
     implementation 'com.github.maricn:logback-slack-appender:1.4.0'

--- a/backend/src/main/java/shook/shook/auth/application/AuthService.java
+++ b/backend/src/main/java/shook/shook/auth/application/AuthService.java
@@ -1,6 +1,7 @@
 package shook.shook.auth.application;
 
 import io.jsonwebtoken.Claims;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import shook.shook.auth.application.dto.GoogleAccessTokenResponse;
@@ -40,6 +41,10 @@ public class AuthService {
     }
 
     public ReissueAccessTokenResponse reissueAccessTokenByRefreshToken(final String refreshToken, final String accessToken) {
+        final Map<String, String> tokenPairs = inMemoryTokenPairRepository.getTokenPairs();
+        for (String a : tokenPairs.keySet()) {
+            System.out.println(a.equals(refreshToken));
+        }
         final Claims claims = tokenProvider.parseClaims(refreshToken);
         final Long memberId = claims.get("memberId", Long.class);
         final String nickname = claims.get("nickname", String.class);

--- a/backend/src/main/java/shook/shook/auth/application/AuthService.java
+++ b/backend/src/main/java/shook/shook/auth/application/AuthService.java
@@ -1,7 +1,6 @@
 package shook.shook.auth.application;
 
 import io.jsonwebtoken.Claims;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import shook.shook.auth.application.dto.GoogleAccessTokenResponse;
@@ -36,22 +35,18 @@ public class AuthService {
         final String nickname = member.getNickname();
         final String accessToken = tokenProvider.createAccessToken(memberId, nickname);
         final String refreshToken = tokenProvider.createRefreshToken(memberId, nickname);
-        inMemoryTokenPairRepository.add(refreshToken, accessToken);
+        inMemoryTokenPairRepository.addOrUpdateTokenPair(refreshToken, accessToken);
         return new TokenPair(accessToken, refreshToken);
     }
 
     public ReissueAccessTokenResponse reissueAccessTokenByRefreshToken(final String refreshToken, final String accessToken) {
-        final Map<String, String> tokenPairs = inMemoryTokenPairRepository.getTokenPairs();
-        for (String a : tokenPairs.keySet()) {
-            System.out.println(a.equals(refreshToken));
-        }
         final Claims claims = tokenProvider.parseClaims(refreshToken);
         final Long memberId = claims.get("memberId", Long.class);
         final String nickname = claims.get("nickname", String.class);
 
         inMemoryTokenPairRepository.validateTokenPair(refreshToken, accessToken);
         final String reissuedAccessToken = tokenProvider.createAccessToken(memberId, nickname);
-        inMemoryTokenPairRepository.update(refreshToken, reissuedAccessToken);
+        inMemoryTokenPairRepository.addOrUpdateTokenPair(refreshToken, reissuedAccessToken);
         return new ReissueAccessTokenResponse(reissuedAccessToken);
     }
 }

--- a/backend/src/main/java/shook/shook/auth/application/TokenPairScheduler.java
+++ b/backend/src/main/java/shook/shook/auth/application/TokenPairScheduler.java
@@ -15,14 +15,14 @@ public class TokenPairScheduler {
     private final InMemoryTokenPairRepository inMemoryTokenPairRepository;
 
     @Scheduled(cron = "${schedules.cron}")
-    public void renewInMemoryTokenPairRepository() {
+    public void removeExpiredTokenPair() {
         final Set<String> refreshTokens = inMemoryTokenPairRepository.getTokenPairs().keySet();
-        refreshTokens.forEach(refreshToken -> {
+        for (String refreshToken : refreshTokens) {
             try {
                 tokenProvider.parseClaims(refreshToken);
             } catch (TokenException.ExpiredTokenException e) {
                 inMemoryTokenPairRepository.delete(refreshToken);
             }
-        });
+        }
     }
 }

--- a/backend/src/main/java/shook/shook/auth/application/TokenPairScheduler.java
+++ b/backend/src/main/java/shook/shook/auth/application/TokenPairScheduler.java
@@ -1,0 +1,28 @@
+package shook.shook.auth.application;
+
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import shook.shook.auth.exception.TokenException;
+import shook.shook.auth.repository.InMemoryTokenPairRepository;
+
+@RequiredArgsConstructor
+@Component
+public class TokenPairScheduler {
+
+    private final TokenProvider tokenProvider;
+    private final InMemoryTokenPairRepository inMemoryTokenPairRepository;
+
+    @Scheduled(cron = "${schedules.cron}")
+    public void renewInMemoryTokenPairRepository() {
+        final Set<String> refreshTokens = inMemoryTokenPairRepository.getTokenPairs().keySet();
+        refreshTokens.forEach(refreshToken -> {
+            try {
+                tokenProvider.parseClaims(refreshToken);
+            } catch (TokenException.ExpiredTokenException e) {
+                inMemoryTokenPairRepository.delete(refreshToken);
+            }
+        });
+    }
+}

--- a/backend/src/main/java/shook/shook/auth/application/dto/ReissueAccessTokenResponse.java
+++ b/backend/src/main/java/shook/shook/auth/application/dto/ReissueAccessTokenResponse.java
@@ -4,11 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Schema(description = "액세스 토큰 재발급 응답")
 @AllArgsConstructor
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class ReissueAccessTokenResponse {
 

--- a/backend/src/main/java/shook/shook/auth/exception/TokenException.java
+++ b/backend/src/main/java/shook/shook/auth/exception/TokenException.java
@@ -38,4 +38,26 @@ public class TokenException extends CustomException {
             super(ErrorCode.EXPIRED_TOKEN, inputValuesByProperty);
         }
     }
+
+    public static class RefreshTokenNotFoundException extends TokenException {
+
+        public RefreshTokenNotFoundException() {
+            super(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        public RefreshTokenNotFoundException(final Map<String, String> inputValuesByProperty) {
+            super(ErrorCode.INVALID_REFRESH_TOKEN, inputValuesByProperty);
+        }
+    }
+
+    public static class TokenPairNotMatchingException extends TokenException {
+
+        public TokenPairNotMatchingException() {
+            super(ErrorCode.TOKEN_PAIR_NOT_MATCHING_EXCEPTION);
+        }
+
+        public TokenPairNotMatchingException(final Map<String, String> inputValuesByProperty) {
+            super(ErrorCode.TOKEN_PAIR_NOT_MATCHING_EXCEPTION, inputValuesByProperty);
+        }
+    }
 }

--- a/backend/src/main/java/shook/shook/auth/repository/InMemoryTokenPairRepository.java
+++ b/backend/src/main/java/shook/shook/auth/repository/InMemoryTokenPairRepository.java
@@ -20,11 +20,7 @@ public class InMemoryTokenPairRepository {
         }
     }
 
-    public void add(final String refreshToken, final String accessToken) {
-        tokenPairs.put(refreshToken, accessToken);
-    }
-
-    public void update(final String refreshToken, final String accessToken) {
+    public void addOrUpdateTokenPair(final String refreshToken, final String accessToken) {
         tokenPairs.put(refreshToken, accessToken);
     }
 

--- a/backend/src/main/java/shook/shook/auth/repository/InMemoryTokenPairRepository.java
+++ b/backend/src/main/java/shook/shook/auth/repository/InMemoryTokenPairRepository.java
@@ -27,4 +27,16 @@ public class InMemoryTokenPairRepository {
     public void update(final String refreshToken, final String accessToken) {
         tokenPairs.put(refreshToken, accessToken);
     }
+
+    public void delete(final String refreshToken) {
+        tokenPairs.remove(refreshToken);
+    }
+
+    public Map<String, String> getTokenPairs() {
+        return tokenPairs;
+    }
+
+    public void clear() {
+        tokenPairs.clear();
+    }
 }

--- a/backend/src/main/java/shook/shook/auth/repository/InMemoryTokenPairRepository.java
+++ b/backend/src/main/java/shook/shook/auth/repository/InMemoryTokenPairRepository.java
@@ -1,0 +1,30 @@
+package shook.shook.auth.repository;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+import shook.shook.auth.exception.TokenException;
+import shook.shook.auth.exception.TokenException.TokenPairNotMatchingException;
+
+@Repository
+public class InMemoryTokenPairRepository {
+
+    private final Map<String, String> tokenPairs = new ConcurrentHashMap<>();
+
+    public void validateTokenPair(final String refreshToken, final String accessToken) {
+        if (!tokenPairs.containsKey(refreshToken)) {
+            throw new TokenException.RefreshTokenNotFoundException(Map.of("wrongRefreshToken", refreshToken));
+        }
+        if (!tokenPairs.get(refreshToken).equals(accessToken)) {
+            throw new TokenPairNotMatchingException(Map.of("wrongAccessToken", accessToken));
+        }
+    }
+
+    public void add(final String refreshToken, final String accessToken) {
+        tokenPairs.put(refreshToken, accessToken);
+    }
+
+    public void update(final String refreshToken, final String accessToken) {
+        tokenPairs.put(refreshToken, accessToken);
+    }
+}

--- a/backend/src/main/java/shook/shook/auth/ui/AccessTokenReissueController.java
+++ b/backend/src/main/java/shook/shook/auth/ui/AccessTokenReissueController.java
@@ -31,7 +31,7 @@ public class AccessTokenReissueController implements AccessTokenReissueApi {
         }
         final String accessToken = authorization.split(TOKEN_PREFIX)[1];
         final ReissueAccessTokenResponse response =
-            authService.reissueAccessTokenByRefreshToken(accessToken, refreshToken);
+            authService.reissueAccessTokenByRefreshToken(refreshToken, accessToken);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/shook/shook/auth/ui/AccessTokenReissueController.java
+++ b/backend/src/main/java/shook/shook/auth/ui/AccessTokenReissueController.java
@@ -1,6 +1,7 @@
 package shook.shook.auth.ui;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,7 +25,7 @@ public class AccessTokenReissueController implements AccessTokenReissueApi {
     @PostMapping("/reissue")
     public ResponseEntity<ReissueAccessTokenResponse> reissueAccessToken(
         @CookieValue(value = REFRESH_TOKEN_KEY, defaultValue = EMPTY_REFRESH_TOKEN) final String refreshToken,
-        @RequestHeader("Authorization") final String authorization
+        @RequestHeader(HttpHeaders.AUTHORIZATION) final String authorization
     ) {
         if (refreshToken.equals(EMPTY_REFRESH_TOKEN)) {
             throw new AuthorizationException.RefreshTokenNotFoundException();

--- a/backend/src/main/java/shook/shook/auth/ui/AccessTokenReissueController.java
+++ b/backend/src/main/java/shook/shook/auth/ui/AccessTokenReissueController.java
@@ -3,7 +3,8 @@ package shook.shook.auth.ui;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import shook.shook.auth.application.AuthService;
 import shook.shook.auth.application.dto.ReissueAccessTokenResponse;
@@ -16,18 +17,21 @@ public class AccessTokenReissueController implements AccessTokenReissueApi {
 
     private static final String EMPTY_REFRESH_TOKEN = "none";
     private static final String REFRESH_TOKEN_KEY = "refreshToken";
+    private static final String TOKEN_PREFIX = "Bearer ";
 
     private final AuthService authService;
 
-    @GetMapping("/reissue")
+    @PostMapping("/reissue")
     public ResponseEntity<ReissueAccessTokenResponse> reissueAccessToken(
-        @CookieValue(value = REFRESH_TOKEN_KEY, defaultValue = EMPTY_REFRESH_TOKEN) final String refreshToken
+        @CookieValue(value = REFRESH_TOKEN_KEY, defaultValue = EMPTY_REFRESH_TOKEN) final String refreshToken,
+        @RequestHeader("Authorization") final String authorization
     ) {
         if (refreshToken.equals(EMPTY_REFRESH_TOKEN)) {
             throw new AuthorizationException.RefreshTokenNotFoundException();
         }
+        final String accessToken = authorization.split(TOKEN_PREFIX)[1];
         final ReissueAccessTokenResponse response =
-            authService.reissueAccessTokenByRefreshToken(refreshToken);
+            authService.reissueAccessTokenByRefreshToken(accessToken, refreshToken);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/shook/shook/auth/ui/openapi/AccessTokenReissueApi.java
+++ b/backend/src/main/java/shook/shook/auth/ui/openapi/AccessTokenReissueApi.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import shook.shook.auth.application.dto.ReissueAccessTokenResponse;
 
@@ -35,7 +35,7 @@ public interface AccessTokenReissueApi {
             )
         }
     )
-    @GetMapping("/reissue")
+    @PostMapping("/reissue")
     ResponseEntity<ReissueAccessTokenResponse> reissueAccessToken(
         final String refreshToken,
         @RequestHeader("Authorization") final String authorization

--- a/backend/src/main/java/shook/shook/auth/ui/openapi/AccessTokenReissueApi.java
+++ b/backend/src/main/java/shook/shook/auth/ui/openapi/AccessTokenReissueApi.java
@@ -2,10 +2,12 @@ package shook.shook.auth.ui.openapi;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import shook.shook.auth.application.dto.ReissueAccessTokenResponse;
 
 @Tag(name = "AccessTokenReissue", description = "액세스 토큰 재발급 API")
@@ -19,13 +21,23 @@ public interface AccessTokenReissueApi {
         responseCode = "200",
         description = "액세스 토큰 재발급 성공"
     )
-    @Parameter(
-        name = "refreshToken",
-        description = "리프레시 토큰",
-        required = true
+    @Parameters(
+        value = {
+            @Parameter(
+                name = "refreshToken",
+                description = "리프레시 토큰",
+                required = true
+            ),
+            @Parameter(
+                name = "authorization",
+                description = "authorization 헤더",
+                required = true
+            )
+        }
     )
     @GetMapping("/reissue")
     ResponseEntity<ReissueAccessTokenResponse> reissueAccessToken(
-        final String refreshToken
+        final String refreshToken,
+        @RequestHeader("Authorization") final String authorization
     );
 }

--- a/backend/src/main/java/shook/shook/globalexception/ErrorCode.java
+++ b/backend/src/main/java/shook/shook/globalexception/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND_EXCEPTION(1006, "accessToken 을 재발급하기 위해서는 refreshToken 이 필요합니다."),
     ACCESS_TOKEN_NOT_FOUND(1007, "accessToken이 필요합니다."),
     UNAUTHENTICATED_EXCEPTION(1008, "권한이 없는 요청입니다."),
+    INVALID_REFRESH_TOKEN(1009, "존재하지 않는 refreshToken 입니다."),
+    TOKEN_PAIR_NOT_MATCHING_EXCEPTION(1010, "올바르지 않은 TokenPair 입니다."),
 
     // 2000: 킬링파트 - 좋아요, 댓글
 

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -40,3 +40,6 @@ excel:
   video-url-delimiter: "="
   killingpart-data-delimiter: " "
   song-length-suffix: "s"
+
+schedules:
+  cron: 0/1 * * * * *

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -58,3 +58,7 @@ excel:
   video-url-delimiter: "v="
   killingpart-data-delimiter: " "
   song-length-suffix: "초"
+
+# Properties Only For local
+schedules:
+  cron: "0 0 0/1 * * *"

--- a/backend/src/test/java/shook/shook/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/shook/shook/auth/application/AuthServiceTest.java
@@ -57,9 +57,8 @@ class AuthServiceTest {
         savedMember = memberRepository.save(new Member("shook@wooteco.com", "shook"));
         refreshToken = tokenProvider.createRefreshToken(savedMember.getId(), savedMember.getNickname());
         accessToken = tokenProvider.createAccessToken(savedMember.getId(), savedMember.getNickname());
-        inMemoryTokenPairRepository.add(refreshToken, accessToken);
+        inMemoryTokenPairRepository.addOrUpdateTokenPair(refreshToken, accessToken);
         authService = new AuthService(memberService, googleInfoProvider, tokenProvider, inMemoryTokenPairRepository);
-
     }
 
     @AfterEach

--- a/backend/src/test/java/shook/shook/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/shook/shook/auth/application/AuthServiceTest.java
@@ -2,6 +2,7 @@ package shook.shook.auth.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -17,6 +18,7 @@ import shook.shook.auth.application.dto.GoogleMemberInfoResponse;
 import shook.shook.auth.application.dto.ReissueAccessTokenResponse;
 import shook.shook.auth.application.dto.TokenPair;
 import shook.shook.auth.exception.TokenException;
+import shook.shook.auth.repository.InMemoryTokenPairRepository;
 import shook.shook.member.application.MemberService;
 import shook.shook.member.domain.Member;
 import shook.shook.member.domain.repository.MemberRepository;
@@ -35,7 +37,14 @@ class AuthServiceTest {
     @Autowired
     private MemberService memberService;
 
+    @Autowired
+    private InMemoryTokenPairRepository inMemoryTokenPairRepository;
+
     private TokenProvider tokenProvider;
+
+    private String refreshToken;
+
+    private String accessToken;
 
     private AuthService authService;
 
@@ -45,8 +54,12 @@ class AuthServiceTest {
             100000L,
             1000000L,
             "asdfsdsvsdf2esvsdvsdvs23");
-        authService = new AuthService(memberService, googleInfoProvider, tokenProvider);
         savedMember = memberRepository.save(new Member("shook@wooteco.com", "shook"));
+        refreshToken = tokenProvider.createRefreshToken(savedMember.getId(), savedMember.getNickname());
+        accessToken = tokenProvider.createAccessToken(savedMember.getId(), savedMember.getNickname());
+        inMemoryTokenPairRepository.add(refreshToken, accessToken);
+        authService = new AuthService(memberService, googleInfoProvider, tokenProvider, inMemoryTokenPairRepository);
+
     }
 
     @AfterEach
@@ -80,19 +93,16 @@ class AuthServiceTest {
 
         assertThat(result.getAccessToken()).isEqualTo(accessToken);
         assertThat(result.getRefreshToken()).isEqualTo(refreshToken);
+        assertDoesNotThrow(() -> inMemoryTokenPairRepository.validateTokenPair(refreshToken, accessToken));
     }
 
-    @DisplayName("올바른 refresh 토큰이 들어오면 access 토큰을 재발급해준다.")
+    @DisplayName("올바른 refresh 토큰과 access 토큰이 들어오면 access 토큰을 재발급해준다.")
     @Test
     void success_reissue() {
         //given
-        final String refreshToken = tokenProvider.createRefreshToken(
-            savedMember.getId(),
-            savedMember.getNickname());
-
         //when
         final ReissueAccessTokenResponse result = authService.reissueAccessTokenByRefreshToken(
-            refreshToken);
+            refreshToken, accessToken);
 
         //then
         final String accessToken = tokenProvider.createAccessToken(
@@ -111,13 +121,13 @@ class AuthServiceTest {
             100L,
             "asdzzxcwetg2adfvssd3xZcZXCZvzx");
 
-        final String refreshToken = inValidTokenProvider.createRefreshToken(
+        final String wrongRefreshToken = inValidTokenProvider.createRefreshToken(
             savedMember.getId(),
             savedMember.getNickname());
 
         //when
         //then
-        assertThatThrownBy(() -> authService.reissueAccessTokenByRefreshToken(refreshToken))
+        assertThatThrownBy(() -> authService.reissueAccessTokenByRefreshToken(wrongRefreshToken, accessToken))
             .isInstanceOf(TokenException.NotIssuedTokenException.class);
     }
 
@@ -136,7 +146,7 @@ class AuthServiceTest {
 
         //when
         //then
-        assertThatThrownBy(() -> authService.reissueAccessTokenByRefreshToken(refreshToken))
+        assertThatThrownBy(() -> authService.reissueAccessTokenByRefreshToken(refreshToken, accessToken))
             .isInstanceOf(TokenException.ExpiredTokenException.class);
     }
 }

--- a/backend/src/test/java/shook/shook/auth/application/TokenPairSchedulerTest.java
+++ b/backend/src/test/java/shook/shook/auth/application/TokenPairSchedulerTest.java
@@ -44,12 +44,12 @@ class TokenPairSchedulerTest {
         final String expiredRefreshToken = expiredTokenProvider.createRefreshToken(2L, "expiredShook");
         final String expiredAccessToken = expiredTokenProvider.createAccessToken(2L, "expiredShook");
 
-        inMemoryTokenPairRepository.add(refreshToken, accessToken);
-        inMemoryTokenPairRepository.add(expiredRefreshToken, expiredAccessToken);
+        inMemoryTokenPairRepository.addOrUpdateTokenPair(refreshToken, accessToken);
+        inMemoryTokenPairRepository.addOrUpdateTokenPair(expiredRefreshToken, expiredAccessToken);
 
         // when
         final TokenPairScheduler tokenPairScheduler = new TokenPairScheduler(tokenProvider, inMemoryTokenPairRepository);
-        tokenPairScheduler.renewInMemoryTokenPairRepository();
+        tokenPairScheduler.removeExpiredTokenPair();
 
         // then
         final Map<String, String> tokenPairs = inMemoryTokenPairRepository.getTokenPairs();
@@ -68,8 +68,8 @@ class TokenPairSchedulerTest {
         final String expiredRefreshToken = expiredTokenProvider.createRefreshToken(2L, "expiredShook");
         final String expiredAccessToken = expiredTokenProvider.createAccessToken(2L, "expiredShook");
 
-        inMemoryTokenPairRepository.add(refreshToken, accessToken);
-        inMemoryTokenPairRepository.add(expiredRefreshToken, expiredAccessToken);
+        inMemoryTokenPairRepository.addOrUpdateTokenPair(refreshToken, accessToken);
+        inMemoryTokenPairRepository.addOrUpdateTokenPair(expiredRefreshToken, expiredAccessToken);
 
         // when
         final Map<String, String> tokenPairs = inMemoryTokenPairRepository.getTokenPairs();
@@ -83,4 +83,3 @@ class TokenPairSchedulerTest {
             });
     }
 }
-

--- a/backend/src/test/java/shook/shook/auth/application/TokenPairSchedulerTest.java
+++ b/backend/src/test/java/shook/shook/auth/application/TokenPairSchedulerTest.java
@@ -1,0 +1,86 @@
+package shook.shook.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import shook.shook.auth.repository.InMemoryTokenPairRepository;
+
+@EnableScheduling
+@SpringBootTest
+class TokenPairSchedulerTest {
+
+    @Autowired
+    private InMemoryTokenPairRepository inMemoryTokenPairRepository;
+
+    private TokenProvider tokenProvider;
+    private TokenProvider expiredTokenProvider;
+
+    @BeforeEach
+    void setting() {
+        tokenProvider = new TokenProvider(1200, 634000, "asdkfwofk23ksdfowsrk4sdkf");
+        expiredTokenProvider = new TokenProvider(0, 0, "asdkfwofk23ksdfowsrk4sdkf");
+    }
+
+    @AfterEach
+    void clear() {
+        inMemoryTokenPairRepository.clear();
+    }
+
+    @DisplayName("tokenPairSechduler를 통해 inMemoryTokenPairRepository를 갱신한다.")
+    @Test
+    void renewInMemoryTokenPairRepository() {
+        // given
+        final String refreshToken = tokenProvider.createRefreshToken(1L, "shook");
+        final String accessToken = tokenProvider.createAccessToken(1L, "shook");
+        final String expiredRefreshToken = expiredTokenProvider.createRefreshToken(2L, "expiredShook");
+        final String expiredAccessToken = expiredTokenProvider.createAccessToken(2L, "expiredShook");
+
+        inMemoryTokenPairRepository.add(refreshToken, accessToken);
+        inMemoryTokenPairRepository.add(expiredRefreshToken, expiredAccessToken);
+
+        // when
+        final TokenPairScheduler tokenPairScheduler = new TokenPairScheduler(tokenProvider, inMemoryTokenPairRepository);
+        tokenPairScheduler.renewInMemoryTokenPairRepository();
+
+        // then
+        final Map<String, String> tokenPairs = inMemoryTokenPairRepository.getTokenPairs();
+
+        assertThat(tokenPairs.size()).isOne();
+        assertThat(tokenPairs.get(refreshToken)).isEqualTo(accessToken);
+        assertThat(tokenPairs.containsKey(expiredRefreshToken)).isFalse();
+    }
+
+    @Test
+    @DisplayName("1초마다 동작하는 scheduler로 inMemoryTokenPairRepository를 갱신한다.")
+    void renewInMemoryTokenPairRepositoryWithScheduler() {
+        // given
+        final String refreshToken = tokenProvider.createRefreshToken(1L, "shook");
+        final String accessToken = tokenProvider.createAccessToken(1L, "shook");
+        final String expiredRefreshToken = expiredTokenProvider.createRefreshToken(2L, "expiredShook");
+        final String expiredAccessToken = expiredTokenProvider.createAccessToken(2L, "expiredShook");
+
+        inMemoryTokenPairRepository.add(refreshToken, accessToken);
+        inMemoryTokenPairRepository.add(expiredRefreshToken, expiredAccessToken);
+
+        // when
+        final Map<String, String> tokenPairs = inMemoryTokenPairRepository.getTokenPairs();
+        // then
+        Awaitility.await()
+            .atMost(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertThat(tokenPairs.size()).isOne();
+                assertThat(tokenPairs.get(refreshToken)).isEqualTo(accessToken);
+                assertThat(tokenPairs.containsKey(expiredRefreshToken)).isFalse();
+            });
+    }
+}
+

--- a/backend/src/test/java/shook/shook/auth/repository/InMemoryTokenPairRepositoryTest.java
+++ b/backend/src/test/java/shook/shook/auth/repository/InMemoryTokenPairRepositoryTest.java
@@ -1,0 +1,50 @@
+package shook.shook.auth.repository;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import shook.shook.auth.exception.TokenException.RefreshTokenNotFoundException;
+import shook.shook.auth.exception.TokenException.TokenPairNotMatchingException;
+
+class InMemoryTokenPairRepositoryTest {
+
+    @DisplayName("refreshToken과 accessToken이 올바른 쌍을 가지고 있으면 예외를 처리하지 않는다.")
+    @Test
+    void successValidateTokenPair() {
+        // given
+        final InMemoryTokenPairRepository inMemoryTokenPairRepository = new InMemoryTokenPairRepository();
+        inMemoryTokenPairRepository.add("refreshToken", "accessToken");
+
+        // when
+        // then
+        assertDoesNotThrow(() -> inMemoryTokenPairRepository.validateTokenPair("refreshToken", "accessToken"));
+    }
+
+    @DisplayName("존재하지 않는 refreshToken이면 예외를 발생한다.")
+    @Test
+    void failValidateTokenPair_refreshTokenNotExist() {
+        // given
+        final InMemoryTokenPairRepository inMemoryTokenPairRepository = new InMemoryTokenPairRepository();
+        inMemoryTokenPairRepository.add("refreshToken", "accessToken");
+
+        // when
+        // then
+        assertThatThrownBy(() -> inMemoryTokenPairRepository.validateTokenPair("wrongRefreshToken", "accessToken"))
+            .isInstanceOf(RefreshTokenNotFoundException.class);
+    }
+
+    @DisplayName("refreshToken에 해당하는 accessToken이 매칭되지 않으면 예외를 발생한다.")
+    @Test
+    void failValidateTokenPair_notMatching() {
+        // given
+        final InMemoryTokenPairRepository inMemoryTokenPairRepository = new InMemoryTokenPairRepository();
+        inMemoryTokenPairRepository.add("refreshToken", "accessToken");
+
+        // when
+        // then
+        assertThatThrownBy(() -> inMemoryTokenPairRepository.validateTokenPair("refreshToken", "wrongAccessToken"))
+            .isInstanceOf(TokenPairNotMatchingException.class);
+    }
+}

--- a/backend/src/test/java/shook/shook/auth/repository/InMemoryTokenPairRepositoryTest.java
+++ b/backend/src/test/java/shook/shook/auth/repository/InMemoryTokenPairRepositoryTest.java
@@ -15,7 +15,7 @@ class InMemoryTokenPairRepositoryTest {
     void successValidateTokenPair() {
         // given
         final InMemoryTokenPairRepository inMemoryTokenPairRepository = new InMemoryTokenPairRepository();
-        inMemoryTokenPairRepository.add("refreshToken", "accessToken");
+        inMemoryTokenPairRepository.addOrUpdateTokenPair("refreshToken", "accessToken");
 
         // when
         // then
@@ -27,7 +27,7 @@ class InMemoryTokenPairRepositoryTest {
     void failValidateTokenPair_refreshTokenNotExist() {
         // given
         final InMemoryTokenPairRepository inMemoryTokenPairRepository = new InMemoryTokenPairRepository();
-        inMemoryTokenPairRepository.add("refreshToken", "accessToken");
+        inMemoryTokenPairRepository.addOrUpdateTokenPair("refreshToken", "accessToken");
 
         // when
         // then
@@ -40,7 +40,7 @@ class InMemoryTokenPairRepositoryTest {
     void failValidateTokenPair_notMatching() {
         // given
         final InMemoryTokenPairRepository inMemoryTokenPairRepository = new InMemoryTokenPairRepository();
-        inMemoryTokenPairRepository.add("refreshToken", "accessToken");
+        inMemoryTokenPairRepository.addOrUpdateTokenPair("refreshToken", "accessToken");
 
         // when
         // then

--- a/backend/src/test/java/shook/shook/auth/ui/AccessTokenReissueControllerTest.java
+++ b/backend/src/test/java/shook/shook/auth/ui/AccessTokenReissueControllerTest.java
@@ -50,7 +50,7 @@ class AccessTokenReissueControllerTest {
         savedMember = memberRepository.save(new Member("shook@wooteco.com", "shook"));
         refreshToken = tokenProvider.createRefreshToken(savedMember.getId(), savedMember.getNickname());
         accessToken = tokenProvider.createAccessToken(savedMember.getId(), savedMember.getNickname());
-        inMemoryTokenPairRepository.add(refreshToken, accessToken);
+        inMemoryTokenPairRepository.addOrUpdateTokenPair(refreshToken, accessToken);
     }
 
     @AfterEach

--- a/backend/src/test/java/shook/shook/auth/ui/AccessTokenReissueControllerTest.java
+++ b/backend/src/test/java/shook/shook/auth/ui/AccessTokenReissueControllerTest.java
@@ -6,7 +6,6 @@ import io.jsonwebtoken.Claims;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +15,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import shook.shook.auth.application.TokenProvider;
 import shook.shook.auth.application.dto.ReissueAccessTokenResponse;
+import shook.shook.auth.repository.InMemoryTokenPairRepository;
 import shook.shook.member.domain.Member;
 import shook.shook.member.domain.repository.MemberRepository;
 import shook.shook.support.DataCleaner;
@@ -37,6 +37,9 @@ class AccessTokenReissueControllerTest {
     @Autowired
     private TokenProvider tokenProvider;
 
+    @Autowired
+    private InMemoryTokenPairRepository inMemoryTokenPairRepository;
+
     private String refreshToken;
     private String accessToken;
 
@@ -47,6 +50,7 @@ class AccessTokenReissueControllerTest {
         savedMember = memberRepository.save(new Member("shook@wooteco.com", "shook"));
         refreshToken = tokenProvider.createRefreshToken(savedMember.getId(), savedMember.getNickname());
         accessToken = tokenProvider.createAccessToken(savedMember.getId(), savedMember.getNickname());
+        inMemoryTokenPairRepository.add(refreshToken, accessToken);
     }
 
     @AfterEach
@@ -54,7 +58,6 @@ class AccessTokenReissueControllerTest {
         memberRepository.delete(savedMember);
     }
 
-    @Disabled
     @DisplayName("올바른 refreshToken을 통해 accessToken 재발급을 요청하면 accessToken과 상태코드 200을 반환한다.")
     @Test
     void success_reissue_accessToken() {

--- a/backend/src/test/java/shook/shook/exceptionhandler/ControllerAdviceTest.java
+++ b/backend/src/test/java/shook/shook/exceptionhandler/ControllerAdviceTest.java
@@ -47,6 +47,8 @@ class ControllerAdviceTest extends AcceptanceTest {
         return Stream.of(
             new ExceptionTestData(new TokenException.NotIssuedTokenException(), 401),
             new ExceptionTestData(new TokenException.ExpiredTokenException(), 401),
+            new ExceptionTestData(new TokenException.TokenPairNotMatchingException(), 401),
+            new ExceptionTestData(new TokenException.RefreshTokenNotFoundException(), 401),
 
             new ExceptionTestData(new OAuthException.InvalidAuthorizationCodeException(), 503),
             new ExceptionTestData(new OAuthException.InvalidAccessTokenException(), 503),


### PR DESCRIPTION
## 📝작업 내용
- refreshToken과 accessToken을 concurrentHashMap으로 관리하도록 구성 (key는 refreshToken으로 value는 accessToken로 관리합니다.)
- 현재 스케줄러를 통해 InMemoryTokenPairRespository를 갱신하고 있습니다.
   -  스케줄러로 관리를 했던 이유는 처음에는 요청 올 때 refreshToken의 유효성을 판단해서 제거를 하려고 했는데 실제로 refreshToken은 cookie로 관리가 되고 있기 때문에 기간이 지나면 refreshToken을 담은 요청이 오지 않아서 메모리에서 삭제되지 않고 계속 유지되는 문제가 있었습니다. 그래서 스케줄러로 관리하는 방식을 택했습니다.
## 💬리뷰 참고사항

- swagger를 다루어 본적이 없어서 swagger 설정을 올바르게 했는지 잘 모르겠습니다.
- 혹시 토큰 메모리를 스케줄러 외의 더 잘 관리할 수 있는 방안이 있으면 의견 부탁드랍나다.🙇‍♂️

## #️⃣연관된 이슈

- close #385 


