### PR TITLE
Hotfix: 엑셀 노래 제목 데이터가 숫자로 구성된 상황을 처리한다.

### DIFF
--- a/backend/src/main/java/shook/shook/song/application/SongDataExcelReader.java
+++ b/backend/src/main/java/shook/shook/song/application/SongDataExcelReader.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
@@ -24,6 +25,7 @@ import shook.shook.song.exception.SongDataFileReadException;
 @Component
 public class SongDataExcelReader {
 
+    private static final DataFormatter CELL_FORMATTER = new DataFormatter();
     private static final int VIDEO_ID_INDEX = 1;
     private static final int FIRST_PAGE_INDEX = 0;
     private static final int SONG_LENGTH_INDEX = 1;
@@ -94,7 +96,9 @@ public class SongDataExcelReader {
     }
 
     private String getString(final Iterator<Cell> iterator) {
-        return iterator.next().getStringCellValue().trim();
+        final String cellValue = CELL_FORMATTER.formatCellValue(iterator.next());
+
+        return cellValue.trim();
     }
 
     private int getIntegerCell(final Iterator<Cell> iterator) {

--- a/backend/src/main/java/shook/shook/song/application/SongDataExcelReader.java
+++ b/backend/src/main/java/shook/shook/song/application/SongDataExcelReader.java
@@ -25,7 +25,7 @@ import shook.shook.song.exception.SongDataFileReadException;
 @Component
 public class SongDataExcelReader {
 
-    private static final DataFormatter CELL_FORMATTER = new DataFormatter();
+    private static final DataFormatter stringDataFormatter = new DataFormatter();
     private static final int VIDEO_ID_INDEX = 1;
     private static final int FIRST_PAGE_INDEX = 0;
     private static final int SONG_LENGTH_INDEX = 1;
@@ -96,7 +96,7 @@ public class SongDataExcelReader {
     }
 
     private String getString(final Iterator<Cell> iterator) {
-        final String cellValue = CELL_FORMATTER.formatCellValue(iterator.next());
+        final String cellValue = stringDataFormatter.formatCellValue(iterator.next());
 
         return cellValue.trim();
     }


### PR DESCRIPTION
## 📝작업 내용

엑셀 노래 제목 데이터가 숫자로 구성된 상황을 처리한다.

## 💬리뷰 참고사항
![image](https://github.com/woowacourse-teams/2023-shook/assets/70891072/358bbdfd-5724-43ff-af33-7c4f4bc6599c)
- 해당 데이터 엑셀 입력 시, 제목셀을 `numericCell`로 인식하는 문제 발생
- DataFormatter로 문자열로 읽어오도록 수정

## #️⃣연관된 이슈



