### PR TITLE
Hotfix: 스와이프 코치마크의 백드랍을 클릭하여도 모달이 닫히지 않도록 수정

### DIFF
--- a/frontend/src/pages/SongDetailListPage.tsx
+++ b/frontend/src/pages/SongDetailListPage.tsx
@@ -95,7 +95,12 @@ const SongDetailListPage = () => {
   return (
     <>
       {onboarding && (
-        <Modal isOpen={isOpen} closeModal={closeCoachMark} css={{ backgroundColor: 'transparent' }}>
+        <Modal
+          isOpen={isOpen}
+          closeModal={closeCoachMark}
+          css={{ backgroundColor: 'transparent' }}
+          canCloseByBackDrop={false}
+        >
           <Spacing direction="vertical" size={170} />
           <img src={swipeUpDown} width="100px" />
           <Spacing direction="vertical" size={30} />

--- a/frontend/src/shared/components/Modal/Modal.tsx
+++ b/frontend/src/shared/components/Modal/Modal.tsx
@@ -9,9 +9,16 @@ interface ModalProps extends HTMLAttributes<HTMLDivElement> {
   closeModal: () => void;
   children: ReactElement | ReactElement[];
   css?: CSSProp;
+  canCloseByBackDrop?: boolean;
 }
 
-const Modal = ({ isOpen, closeModal, children, css }: PropsWithChildren<ModalProps>) => {
+const Modal = ({
+  canCloseByBackDrop = true,
+  isOpen,
+  closeModal,
+  children,
+  css,
+}: PropsWithChildren<ModalProps>) => {
   const closeByEsc = useCallback(
     ({ key }: KeyboardEvent) => {
       if (key === 'Escape') {
@@ -20,6 +27,12 @@ const Modal = ({ isOpen, closeModal, children, css }: PropsWithChildren<ModalPro
     },
     [closeModal]
   );
+
+  const closeModalByBackDrop = () => {
+    if (!canCloseByBackDrop) return;
+
+    closeModal();
+  };
 
   useEffect(() => {
     if (isOpen) {
@@ -37,7 +50,7 @@ const Modal = ({ isOpen, closeModal, children, css }: PropsWithChildren<ModalPro
     <>
       {isOpen && (
         <Wrapper>
-          <Backdrop role="backdrop" onClick={closeModal} aria-hidden="true" />
+          <Backdrop role="backdrop" onClick={closeModalByBackDrop} aria-hidden="true" />
           <Container role="dialog" $css={css}>
             {children}
           </Container>


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

스와이프 코치마크의 백드랍을 클릭하여도 모달이 닫히지 않도록 수정하였습니다.

## 💬리뷰 참고사항

> 원활한 리뷰를 위해 전달하고 싶은 맥락(특정 파일, 디렉터리 등등)  
> 리뷰어가 특별히 봐주었으면 하는 부분

canCloseByBackDrop 속성을 추가하여 backdrop 클릭시 canCloseByBackDrop 여부를 확인하고 닫히도록 수정하였습니다.

#432 PR 참고

## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성

close #431 


