### PR TITLE
Fix/#445 preCheckAccessToken 로직 변경

### DIFF
--- a/frontend/src/shared/remotes/preCheckAccessToken.ts
+++ b/frontend/src/shared/remotes/preCheckAccessToken.ts
@@ -1,6 +1,4 @@
-import AuthError from '@/shared/remotes/AuthError';
 import accessTokenStorage from '@/shared/utils/accessTokenStorage';
-import type { ErrorResponse } from '@/shared/remotes/index';
 
 const isTokenExpiredAfter60seconds = (tokenExp: number) => {
   return tokenExp * 1000 - 30 * 1000 < Date.now();
@@ -31,13 +29,7 @@ const preCheckAccessToken = async () => {
       accessTokenStorage.setToken(accessToken);
       return accessToken;
     }
-
-    const errorResponse: ErrorResponse = await response.json();
-
-    if (response.status === 401) {
-      throw new AuthError(errorResponse);
-    }
-    // 기타 상태코드 처리
+    accessTokenStorage.removeToken();
   }
 
   return null;


### PR DESCRIPTION
## 📝작업 내용
### 문제 상황
- 이전 과정 
  - 인증이 필요없는 요청 
  - refresh 만료로 인해 토큰 갱신과정에서 401 발생
  - error 발생 후 로그인하라는 모달 띄워준다.
 
문제는 인증이 필요한 요청임에도 로그인 모달을 띄워주고, 본 요청이 실행되지 않습니다. 이를 막기 위해 코드를 수정했습니다.

- 변경 이후
  - 인증이 필요없는 요청
   - refresh 만료로 인해 토큰 갱신과정에서 실패
   - access token 삭제
   - 본 요청 발생
## #️⃣연관된 이슈
close #445


