### PR TITLE
Refactor/#461 같은 멤버가 등록중인 노래에 같은 부분을 킬링파트로 등록시 추가 데이터를 저장하지 않는 기능 구현

### DIFF
--- a/backend/src/main/java/shook/shook/voting_song/application/VotingSongPartService.java
+++ b/backend/src/main/java/shook/shook/voting_song/application/VotingSongPartService.java
@@ -1,13 +1,14 @@
 package shook.shook.voting_song.application;
 
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shook.shook.auth.ui.argumentresolver.MemberInfo;
 import shook.shook.member.domain.Member;
 import shook.shook.member.domain.repository.MemberRepository;
-import shook.shook.member.exception.MemberException.MemberNotExistException;
+import shook.shook.member.exception.MemberException;
 import shook.shook.part.domain.PartLength;
 import shook.shook.voting_song.application.dto.VotingSongPartRegisterRequest;
 import shook.shook.voting_song.domain.Vote;
@@ -36,20 +37,25 @@ public class VotingSongPartService {
         final long memberId = memberInfo.getMemberId();
         final Member member = findMemberThrowIfNotExist(memberId);
         final VotingSong votingSong = findVotingSongThrowIfNotExist(votingSongId);
+
         final int startSecond = request.getStartSecond();
         final PartLength partLength = PartLength.findBySecond(request.getLength());
-        final VotingSongPart votingSongPart = VotingSongPart.forSave(member, startSecond, partLength, votingSong);
 
-        if (isMemberSamePartExist(votingSongPart)) {
-            return true;
+        final Optional<VotingSongPart> findVotingSongPart =
+            votingSongPartRepository.findByVotingSongAndStartSecondAndLength(votingSong, startSecond, partLength);
+
+        if (findVotingSongPart.isPresent()) {
+            return voteToExistVotingSongPartAndReturnVoteDuplication(member, votingSong, findVotingSongPart.get());
         }
-        votePart(votingSong, votingSongPart);
+
+        final VotingSongPart newVotingSongPart = VotingSongPart.forSave(startSecond, partLength, votingSong);
+        addPartAndVote(member, votingSong, newVotingSongPart);
         return false;
     }
 
     private Member findMemberThrowIfNotExist(final Long memberId) {
         return memberRepository.findById(memberId)
-            .orElseThrow(MemberNotExistException::new);
+            .orElseThrow(MemberException.MemberNotExistException::new);
     }
 
     private VotingSong findVotingSongThrowIfNotExist(final Long votingSongId) {
@@ -60,31 +66,23 @@ public class VotingSongPartService {
             });
     }
 
-    private boolean isMemberSamePartExist(final VotingSongPart votingSongPart) {
-        return votingSongPartRepository.existsByVotingSongAndMemberAndStartSecondAndLength(
-            votingSongPart.getVotingSong(),
-            votingSongPart.getMember(),
-            votingSongPart.getStartSecond(),
-            votingSongPart.getLength()
-        );
-    }
-
-    private void votePart(final VotingSong votingSong, final VotingSongPart votingSongPart) {
-        if (votingSong.isUniquePart(votingSongPart)) {
-            addPartAndVote(votingSong, votingSongPart);
-            return;
+    private boolean voteToExistVotingSongPartAndReturnVoteDuplication(final Member member,
+                                                                      final VotingSong votingSong,
+                                                                      final VotingSongPart votingSongPart) {
+        if (isMemberSameVoteExist(member, votingSongPart)) {
+            return true;
         }
-        voteToExistPart(votingSong, votingSongPart);
+        voteToExistPart(member, votingSong, votingSongPart);
+        return false;
     }
 
-    private void addPartAndVote(final VotingSong votingSong, final VotingSongPart votingSongPart) {
-        votingSong.addPart(votingSongPart);
-        votingSongPartRepository.save(votingSongPart);
-
-        voteToPart(votingSongPart);
+    private boolean isMemberSameVoteExist(final Member member, final VotingSongPart votingSongPart) {
+        return voteRepository.existsByMemberAndVotingSongPart(member, votingSongPart);
     }
 
-    private void voteToExistPart(final VotingSong votingSong, final VotingSongPart votingSongPart) {
+    private void voteToExistPart(final Member member,
+                                 final VotingSong votingSong,
+                                 final VotingSongPart votingSongPart) {
         final VotingSongPart existPart = votingSong.getSameLengthPartStartAt(votingSongPart)
             .orElseThrow(() -> new VotingSongPartException.PartNotExistException(
                 Map.of(
@@ -94,12 +92,19 @@ public class VotingSongPartService {
                 )
             ));
 
-        voteToPart(existPart);
+        voteToPart(member, existPart);
     }
 
-    private void voteToPart(final VotingSongPart votingSongPart) {
-        final Vote newVote = Vote.forSave(votingSongPart);
+    private void voteToPart(final Member member, final VotingSongPart votingSongPart) {
+        final Vote newVote = Vote.forSave(member, votingSongPart);
         votingSongPart.vote(newVote);
         voteRepository.save(newVote);
+    }
+
+    private void addPartAndVote(final Member member, final VotingSong votingSong, final VotingSongPart votingSongPart) {
+        votingSong.addPart(votingSongPart);
+        votingSongPartRepository.save(votingSongPart);
+
+        voteToPart(member, votingSongPart);
     }
 }

--- a/backend/src/main/java/shook/shook/voting_song/application/VotingSongPartService.java
+++ b/backend/src/main/java/shook/shook/voting_song/application/VotingSongPartService.java
@@ -69,14 +69,14 @@ public class VotingSongPartService {
     private boolean voteToExistVotingSongPartAndReturnVoteDuplication(final Member member,
                                                                       final VotingSong votingSong,
                                                                       final VotingSongPart votingSongPart) {
-        if (isMemberSameVoteExist(member, votingSongPart)) {
+        if (existSameVoteByMember(member, votingSongPart)) {
             return true;
         }
         voteToExistPart(member, votingSong, votingSongPart);
         return false;
     }
 
-    private boolean isMemberSameVoteExist(final Member member, final VotingSongPart votingSongPart) {
+    private boolean existSameVoteByMember(final Member member, final VotingSongPart votingSongPart) {
         return voteRepository.existsByMemberAndVotingSongPart(member, votingSongPart);
     }
 

--- a/backend/src/main/java/shook/shook/voting_song/domain/Vote.java
+++ b/backend/src/main/java/shook/shook/voting_song/domain/Vote.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import shook.shook.member.domain.Member;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -32,20 +33,25 @@ public class Vote {
     @JoinColumn(name = "voting_song_part_id", foreignKey = @ForeignKey(name = "none"), updatable = false, nullable = false)
     private VotingSongPart votingSongPart;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "none"), updatable = false, nullable = false)
+    private Member member;
+
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
 
-    private Vote(final Long id, final VotingSongPart votingSongPart) {
+    private Vote(final Long id, final Member member, final VotingSongPart votingSongPart) {
         this.id = id;
+        this.member = member;
         this.votingSongPart = votingSongPart;
     }
 
-    public static Vote saved(final Long id, final VotingSongPart votingSongPart) {
-        return new Vote(id, votingSongPart);
+    public static Vote saved(final Long id, final Member member, final VotingSongPart votingSongPart) {
+        return new Vote(id, member, votingSongPart);
     }
 
-    public static Vote forSave(final VotingSongPart votingSongPart) {
-        return new Vote(null, votingSongPart);
+    public static Vote forSave(final Member member, final VotingSongPart votingSongPart) {
+        return new Vote(null, member, votingSongPart);
     }
 
     @PrePersist

--- a/backend/src/main/java/shook/shook/voting_song/domain/VotingSongPart.java
+++ b/backend/src/main/java/shook/shook/voting_song/domain/VotingSongPart.java
@@ -20,9 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import shook.shook.member.domain.Member;
 import shook.shook.part.domain.PartLength;
 import shook.shook.part.exception.PartException;
 import shook.shook.voting_song.exception.VoteException;
@@ -48,7 +48,6 @@ public class VotingSongPart {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "voting_song_id", foreignKey = @ForeignKey(name = "none"), updatable = false, nullable = false)
-    @Getter(AccessLevel.NONE)
     private VotingSong votingSong;
 
     @OneToMany(mappedBy = "votingSongPart")
@@ -57,6 +56,10 @@ public class VotingSongPart {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "none"), updatable = false, nullable = false)
+    private Member member;
+
     @PrePersist
     private void prePersist() {
         createdAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
@@ -64,11 +67,13 @@ public class VotingSongPart {
 
     private VotingSongPart(
         final Long id,
+        final Member member,
         final int startSecond,
         final PartLength length,
         final VotingSong votingSong
     ) {
         this.id = id;
+        this.member = member;
         this.startSecond = startSecond;
         this.length = length;
         this.votingSong = votingSong;
@@ -76,12 +81,13 @@ public class VotingSongPart {
 
     public static VotingSongPart saved(
         final Long id,
+        final Member member,
         final int startSecond,
         final PartLength length,
         final VotingSong votingSong
     ) {
         validateStartSecond(startSecond, length, votingSong.getLength());
-        return new VotingSongPart(id, startSecond, length, votingSong);
+        return new VotingSongPart(id, member, startSecond, length, votingSong);
     }
 
     private static void validateStartSecond(
@@ -110,12 +116,13 @@ public class VotingSongPart {
     }
 
     public static VotingSongPart forSave(
+        final Member member,
         final int startSecond,
         final PartLength length,
         final VotingSong votingSong
     ) {
         validateStartSecond(startSecond, length, votingSong.getLength());
-        return new VotingSongPart(null, startSecond, length, votingSong);
+        return new VotingSongPart(null, member, startSecond, length, votingSong);
     }
 
     public void vote(final Vote vote) {

--- a/backend/src/main/java/shook/shook/voting_song/domain/VotingSongPart.java
+++ b/backend/src/main/java/shook/shook/voting_song/domain/VotingSongPart.java
@@ -20,9 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import shook.shook.member.domain.Member;
 import shook.shook.part.domain.PartLength;
 import shook.shook.part.exception.PartException;
 import shook.shook.voting_song.exception.VoteException;
@@ -48,6 +48,7 @@ public class VotingSongPart {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "voting_song_id", foreignKey = @ForeignKey(name = "none"), updatable = false, nullable = false)
+    @Getter(AccessLevel.NONE)
     private VotingSong votingSong;
 
     @OneToMany(mappedBy = "votingSongPart")
@@ -56,10 +57,6 @@ public class VotingSongPart {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "none"), updatable = false, nullable = false)
-    private Member member;
-
     @PrePersist
     private void prePersist() {
         createdAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
@@ -67,13 +64,11 @@ public class VotingSongPart {
 
     private VotingSongPart(
         final Long id,
-        final Member member,
         final int startSecond,
         final PartLength length,
         final VotingSong votingSong
     ) {
         this.id = id;
-        this.member = member;
         this.startSecond = startSecond;
         this.length = length;
         this.votingSong = votingSong;
@@ -81,13 +76,12 @@ public class VotingSongPart {
 
     public static VotingSongPart saved(
         final Long id,
-        final Member member,
         final int startSecond,
         final PartLength length,
         final VotingSong votingSong
     ) {
         validateStartSecond(startSecond, length, votingSong.getLength());
-        return new VotingSongPart(id, member, startSecond, length, votingSong);
+        return new VotingSongPart(id, startSecond, length, votingSong);
     }
 
     private static void validateStartSecond(
@@ -116,13 +110,12 @@ public class VotingSongPart {
     }
 
     public static VotingSongPart forSave(
-        final Member member,
         final int startSecond,
         final PartLength length,
         final VotingSong votingSong
     ) {
         validateStartSecond(startSecond, length, votingSong.getLength());
-        return new VotingSongPart(null, member, startSecond, length, votingSong);
+        return new VotingSongPart(null, startSecond, length, votingSong);
     }
 
     public void vote(final Vote vote) {

--- a/backend/src/main/java/shook/shook/voting_song/domain/VotingSongParts.java
+++ b/backend/src/main/java/shook/shook/voting_song/domain/VotingSongParts.java
@@ -37,9 +37,7 @@ public class VotingSongParts {
 
     public boolean isUniquePart(final VotingSongPart newVotingSongPart) {
         return votingSongParts.stream()
-            .noneMatch(
-                (votingSongPart) -> votingSongPart.hasEqualStartAndLength(newVotingSongPart)
-            );
+            .noneMatch(votingSongPart -> votingSongPart.hasEqualStartAndLength(newVotingSongPart));
     }
 
     public Optional<VotingSongPart> getSameLengthPartStartAt(final VotingSongPart other) {

--- a/backend/src/main/java/shook/shook/voting_song/domain/repository/VoteRepository.java
+++ b/backend/src/main/java/shook/shook/voting_song/domain/repository/VoteRepository.java
@@ -2,9 +2,12 @@ package shook.shook.voting_song.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import shook.shook.member.domain.Member;
 import shook.shook.voting_song.domain.Vote;
+import shook.shook.voting_song.domain.VotingSongPart;
 
 @Repository
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 
+    boolean existsByMemberAndVotingSongPart(final Member member, final VotingSongPart part);
 }

--- a/backend/src/main/java/shook/shook/voting_song/domain/repository/VotingSongPartRepository.java
+++ b/backend/src/main/java/shook/shook/voting_song/domain/repository/VotingSongPartRepository.java
@@ -1,9 +1,9 @@
 package shook.shook.voting_song.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import shook.shook.member.domain.Member;
 import shook.shook.part.domain.PartLength;
 import shook.shook.voting_song.domain.VotingSong;
 import shook.shook.voting_song.domain.VotingSongPart;
@@ -13,8 +13,6 @@ public interface VotingSongPartRepository extends JpaRepository<VotingSongPart, 
 
     List<VotingSongPart> findAllByVotingSong(final VotingSong song);
 
-    boolean existsByVotingSongAndMemberAndStartSecondAndLength(final VotingSong votingSong,
-                                                               final Member member,
-                                                               final int startSecond,
-                                                               final PartLength length);
+    Optional<VotingSongPart> findByVotingSongAndStartSecondAndLength(final VotingSong votingSong,
+                                                                     final int startSecond, final PartLength length);
 }

--- a/backend/src/main/java/shook/shook/voting_song/domain/repository/VotingSongPartRepository.java
+++ b/backend/src/main/java/shook/shook/voting_song/domain/repository/VotingSongPartRepository.java
@@ -3,6 +3,8 @@ package shook.shook.voting_song.domain.repository;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import shook.shook.member.domain.Member;
+import shook.shook.part.domain.PartLength;
 import shook.shook.voting_song.domain.VotingSong;
 import shook.shook.voting_song.domain.VotingSongPart;
 
@@ -10,4 +12,9 @@ import shook.shook.voting_song.domain.VotingSongPart;
 public interface VotingSongPartRepository extends JpaRepository<VotingSongPart, Long> {
 
     List<VotingSongPart> findAllByVotingSong(final VotingSong song);
+
+    boolean existsByVotingSongAndMemberAndStartSecondAndLength(final VotingSong votingSong,
+                                                               final Member member,
+                                                               final int startSecond,
+                                                               final PartLength length);
 }

--- a/backend/src/main/java/shook/shook/voting_song/ui/VotingSongPartController.java
+++ b/backend/src/main/java/shook/shook/voting_song/ui/VotingSongPartController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import shook.shook.auth.ui.argumentresolver.Authenticated;
+import shook.shook.auth.ui.argumentresolver.MemberInfo;
 import shook.shook.voting_song.application.VotingSongPartService;
 import shook.shook.voting_song.application.dto.VotingSongPartRegisterRequest;
 import shook.shook.voting_song.ui.openapi.VotingSongPartApi;
@@ -21,12 +23,15 @@ public class VotingSongPartController implements VotingSongPartApi {
     private final VotingSongPartService votingSongPartService;
 
     @PostMapping
-    public ResponseEntity<Void> registerPart(
-        @PathVariable(name = "voting_song_id") final Long votingSongId,
-        @Valid @RequestBody final VotingSongPartRegisterRequest request
-    ) {
-        votingSongPartService.register(votingSongId, request);
+    public ResponseEntity<Void> registerPart(@Authenticated final MemberInfo memberInfo,
+                                             @PathVariable(name = "voting_song_id") final Long votingSongId,
+                                             @Valid @RequestBody final VotingSongPartRegisterRequest request) {
+        final boolean memberPartDuplication =
+            votingSongPartService.registerAndReturnMemberPartDuplication(memberInfo, votingSongId, request);
 
+        if (memberPartDuplication) {
+            return ResponseEntity.ok().build();
+        }
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/backend/src/main/java/shook/shook/voting_song/ui/openapi/VotingSongPartApi.java
+++ b/backend/src/main/java/shook/shook/voting_song/ui/openapi/VotingSongPartApi.java
@@ -9,6 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import shook.shook.auth.ui.argumentresolver.Authenticated;
+import shook.shook.auth.ui.argumentresolver.MemberInfo;
 import shook.shook.voting_song.application.dto.VotingSongPartRegisterRequest;
 
 @Tag(name = "VotingSongPart", description = "파트 수집 중인 노래의 파트 API")
@@ -27,8 +29,15 @@ public interface VotingSongPartApi {
         description = "파트 수집 중인 노래의 id",
         required = true
     )
+    @Parameter(
+        name = "memberInfo",
+        description = "토큰을 파싱해서 얻은 회원 정보",
+        required = true,
+        hidden = true
+    )
     @PostMapping
     ResponseEntity<Void> registerPart(
+        @Authenticated final MemberInfo memberInfo,
         @PathVariable(name = "voting_song_id") final Long votingSongId,
         @Valid @RequestBody final VotingSongPartRegisterRequest request
     );

--- a/backend/src/main/resources/dev/schema.sql
+++ b/backend/src/main/resources/dev/schema.sql
@@ -71,7 +71,6 @@ create table if not exists voting_song_part
     start_second   integer      not null,
     length         varchar(255) not null check (length in ('SHORT', 'STANDARD', 'LONG')),
     voting_song_id bigint       not null,
-    member_id      bigint       not null,
     created_at     timestamp(6) not null,
     primary key (id)
 );
@@ -79,6 +78,7 @@ create table if not exists vote
 (
     id                  bigint auto_increment,
     voting_song_part_id bigint       not null,
+    member_id           bigint       not null,
     created_at          timestamp(6) not null,
     primary key (id)
 );

--- a/backend/src/main/resources/dev/schema.sql
+++ b/backend/src/main/resources/dev/schema.sql
@@ -71,6 +71,7 @@ create table if not exists voting_song_part
     start_second   integer      not null,
     length         varchar(255) not null check (length in ('SHORT', 'STANDARD', 'LONG')),
     voting_song_id bigint       not null,
+    member_id      bigint       not null,
     created_at     timestamp(6) not null,
     primary key (id)
 );

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -92,3 +92,5 @@ alter table song
     add column genre varchar(255) check
         (genre in ('BALLAD', 'DANCE', 'HIPHOP', 'RHYTHM_AND_BLUES', 'INDIE', 'ROCK_METAL', 'TROT',
                    'FOLK_BLUES', 'POP', 'JAZZ', 'CLASSIC', 'J_POP', 'EDM', 'ETC'));
+alter table voting_song_part
+    add column member_id bigint not null;

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -92,5 +92,5 @@ alter table song
     add column genre varchar(255) check
         (genre in ('BALLAD', 'DANCE', 'HIPHOP', 'RHYTHM_AND_BLUES', 'INDIE', 'ROCK_METAL', 'TROT',
                    'FOLK_BLUES', 'POP', 'JAZZ', 'CLASSIC', 'J_POP', 'EDM', 'ETC'));
-alter table voting_song_part
+alter table vote
     add column member_id bigint not null;

--- a/backend/src/test/java/shook/shook/song/application/killingpart/KillingPartCommentServiceTest.java
+++ b/backend/src/test/java/shook/shook/song/application/killingpart/KillingPartCommentServiceTest.java
@@ -51,8 +51,7 @@ class KillingPartCommentServiceTest extends UsingJpaTest {
     @Test
     void register() {
         //given
-        final KillingPartCommentRegisterRequest request = new KillingPartCommentRegisterRequest(
-            "댓글 내용");
+        final KillingPartCommentRegisterRequest request = new KillingPartCommentRegisterRequest("댓글 내용");
 
         //when
         killingPartCommentService.register(SAVED_PART.getId(), request, MEMBER_ID);

--- a/backend/src/test/java/shook/shook/voting_song/application/VotingSongPartServiceTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/application/VotingSongPartServiceTest.java
@@ -92,10 +92,10 @@ class VotingSongPartServiceTest extends UsingJpaTest {
         @Test
         void registered_membersSamePartExist() {
             //given
-            final VotingSongPart votingSongPart = VotingSongPart.forSave(FIRST_MEMBER, 1, PartLength.SHORT, SAVED_SONG);
+            final VotingSongPart votingSongPart = VotingSongPart.forSave(1, PartLength.SHORT, SAVED_SONG);
             addPart(SAVED_SONG, votingSongPart);
 
-            final Vote vote = Vote.forSave(votingSongPart);
+            final Vote vote = Vote.forSave(FIRST_MEMBER, votingSongPart);
             votePart(votingSongPart, vote);
 
             final VotingSongPartRegisterRequest request = new VotingSongPartRegisterRequest(1, 5);
@@ -117,10 +117,10 @@ class VotingSongPartServiceTest extends UsingJpaTest {
         @Test
         void registered() {
             //given
-            final VotingSongPart votingSongPart = VotingSongPart.forSave(FIRST_MEMBER, 1, PartLength.SHORT, SAVED_SONG);
+            final VotingSongPart votingSongPart = VotingSongPart.forSave(1, PartLength.SHORT, SAVED_SONG);
             addPart(SAVED_SONG, votingSongPart);
 
-            final Vote vote = Vote.forSave(votingSongPart);
+            final Vote vote = Vote.forSave(FIRST_MEMBER, votingSongPart);
             votePart(votingSongPart, vote);
 
             final VotingSongPartRegisterRequest request = new VotingSongPartRegisterRequest(1, 5);

--- a/backend/src/test/java/shook/shook/voting_song/application/VotingSongPartServiceTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/application/VotingSongPartServiceTest.java
@@ -9,6 +9,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import shook.shook.auth.ui.Authority;
+import shook.shook.auth.ui.argumentresolver.MemberInfo;
+import shook.shook.member.domain.Member;
+import shook.shook.member.domain.repository.MemberRepository;
 import shook.shook.part.domain.PartLength;
 import shook.shook.support.UsingJpaTest;
 import shook.shook.voting_song.application.dto.VotingSongPartRegisterRequest;
@@ -23,6 +27,11 @@ import shook.shook.voting_song.exception.VotingSongException;
 class VotingSongPartServiceTest extends UsingJpaTest {
 
     private static VotingSong SAVED_SONG;
+    private static Member FIRST_MEMBER;
+    private static Member SECOND_MEMBER;
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Autowired
     private VotingSongRepository votingSongRepository;
@@ -38,12 +47,14 @@ class VotingSongPartServiceTest extends UsingJpaTest {
     @BeforeEach
     void setUp() {
         votingSongPartService = new VotingSongPartService(
+            memberRepository,
             votingSongRepository,
             votingSongPartRepository,
             voteRepository
         );
-        SAVED_SONG =
-            votingSongRepository.save(new VotingSong("노래제목", "비디오ID는 11글자", "이미지URL", "가수", 180));
+        FIRST_MEMBER = memberRepository.save(new Member("a@a.com", "nickname"));
+        SECOND_MEMBER = memberRepository.save(new Member("b@b.com", "nickname"));
+        SAVED_SONG = votingSongRepository.save(new VotingSong("노래제목", "비디오ID는 11글자", "이미지URL", "가수", 180));
     }
 
     void addPart(final VotingSong votingSong, final VotingSongPart votingSongPart) {
@@ -65,24 +76,23 @@ class VotingSongPartServiceTest extends UsingJpaTest {
         void notRegistered() {
             //given
             final VotingSongPartRegisterRequest request = new VotingSongPartRegisterRequest(1, 10);
+            final MemberInfo memberInfo = new MemberInfo(FIRST_MEMBER.getId(), Authority.MEMBER);
 
             //when
-            votingSongPartService.register(SAVED_SONG.getId(), request);
+            votingSongPartService.registerAndReturnMemberPartDuplication(memberInfo, SAVED_SONG.getId(), request);
             saveAndClearEntityManager();
 
             //then
-            final List<VotingSongPart> votingSongs =
-                votingSongPartRepository.findAllByVotingSong(SAVED_SONG);
+            final List<VotingSongPart> votingSongs = votingSongPartRepository.findAllByVotingSong(SAVED_SONG);
             assertThat(votingSongs).hasSize(1);
             assertThat(votingSongs.get(0).getVoteCount()).isOne();
         }
 
-        @DisplayName("이미 등록된 파트일 때 파트의 투표수가 1 증가한다.")
+        @DisplayName("이미 등록된 동일한 사람의 파트일 때 파트의 투표수가 유지된다.")
         @Test
-        void registered() {
+        void registered_membersSamePartExist() {
             //given
-            final VotingSongPart votingSongPart =
-                VotingSongPart.forSave(1, PartLength.SHORT, SAVED_SONG);
+            final VotingSongPart votingSongPart = VotingSongPart.forSave(FIRST_MEMBER, 1, PartLength.SHORT, SAVED_SONG);
             addPart(SAVED_SONG, votingSongPart);
 
             final Vote vote = Vote.forSave(votingSongPart);
@@ -91,7 +101,34 @@ class VotingSongPartServiceTest extends UsingJpaTest {
             final VotingSongPartRegisterRequest request = new VotingSongPartRegisterRequest(1, 5);
 
             //when
-            votingSongPartService.register(SAVED_SONG.getId(), request);
+            final MemberInfo anotherMemberInfo = new MemberInfo(FIRST_MEMBER.getId(), Authority.MEMBER);
+            votingSongPartService.registerAndReturnMemberPartDuplication(anotherMemberInfo, SAVED_SONG.getId(),
+                request);
+            saveAndClearEntityManager();
+
+            //then
+            final List<VotingSongPart> findParts =
+                votingSongPartRepository.findAllByVotingSong(SAVED_SONG);
+            assertThat(findParts).hasSize(1);
+            assertThat(findParts.get(0).getVoteCount()).isEqualTo(1);
+        }
+
+        @DisplayName("이미 등록된 다른 사람의 파트일 때 파트의 투표수가 1 증가한다.")
+        @Test
+        void registered() {
+            //given
+            final VotingSongPart votingSongPart = VotingSongPart.forSave(FIRST_MEMBER, 1, PartLength.SHORT, SAVED_SONG);
+            addPart(SAVED_SONG, votingSongPart);
+
+            final Vote vote = Vote.forSave(votingSongPart);
+            votePart(votingSongPart, vote);
+
+            final VotingSongPartRegisterRequest request = new VotingSongPartRegisterRequest(1, 5);
+
+            //when
+            final MemberInfo anotherMemberInfo = new MemberInfo(SECOND_MEMBER.getId(), Authority.MEMBER);
+            votingSongPartService.registerAndReturnMemberPartDuplication(anotherMemberInfo, SAVED_SONG.getId(),
+                request);
             saveAndClearEntityManager();
 
             //then
@@ -105,12 +142,14 @@ class VotingSongPartServiceTest extends UsingJpaTest {
         @Test
         void songNotExist() {
             //given
+            final MemberInfo memberInfo = new MemberInfo(FIRST_MEMBER.getId(), Authority.MEMBER);
             final VotingSongPartRegisterRequest request = new VotingSongPartRegisterRequest(1, 10);
             final long notExistSongId = 0L;
 
             //when
             //then
-            assertThatThrownBy(() -> votingSongPartService.register(notExistSongId, request))
+            assertThatThrownBy(
+                () -> votingSongPartService.registerAndReturnMemberPartDuplication(memberInfo, notExistSongId, request))
                 .isInstanceOf(VotingSongException.VotingSongNotExistException.class);
         }
     }

--- a/backend/src/test/java/shook/shook/voting_song/domain/VotingSongPartTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/domain/VotingSongPartTest.java
@@ -21,8 +21,8 @@ class VotingSongPartTest {
     @Test
     void equals_true() {
         //given
-        final VotingSongPart firstPart = VotingSongPart.saved(1L, MEMBER, 4, PartLength.SHORT, votingSong);
-        final VotingSongPart secondPart = VotingSongPart.saved(1L, MEMBER, 14, PartLength.SHORT,
+        final VotingSongPart firstPart = VotingSongPart.saved(1L, 4, PartLength.SHORT, votingSong);
+        final VotingSongPart secondPart = VotingSongPart.saved(1L, 14, PartLength.SHORT,
             votingSong);
 
         //when
@@ -41,9 +41,9 @@ class VotingSongPartTest {
         void equals_false_nullId() {
             //given
             final VotingSongPart firstPart =
-                VotingSongPart.saved(null, MEMBER, 4, PartLength.SHORT, votingSong);
+                VotingSongPart.saved(null, 4, PartLength.SHORT, votingSong);
             final VotingSongPart secondPart =
-                VotingSongPart.saved(1L, MEMBER, 14, PartLength.SHORT, votingSong);
+                VotingSongPart.saved(1L, 14, PartLength.SHORT, votingSong);
 
             //when
             final boolean equals = firstPart.equals(secondPart);
@@ -57,9 +57,9 @@ class VotingSongPartTest {
         void equals_false_bothNullId() {
             //given
             final VotingSongPart firstPart =
-                VotingSongPart.saved(null, MEMBER, 4, PartLength.SHORT, votingSong);
+                VotingSongPart.saved(null, 4, PartLength.SHORT, votingSong);
             final VotingSongPart secondPart =
-                VotingSongPart.saved(null, MEMBER, 14, PartLength.SHORT, votingSong);
+                VotingSongPart.saved(null, 14, PartLength.SHORT, votingSong);
 
             //when
             final boolean equals = firstPart.equals(secondPart);
@@ -79,7 +79,7 @@ class VotingSongPartTest {
             //given
             //when
             //then
-            assertDoesNotThrow(() -> VotingSongPart.forSave(MEMBER, 14, PartLength.SHORT, votingSong));
+            assertDoesNotThrow(() -> VotingSongPart.forSave(14, PartLength.SHORT, votingSong));
         }
 
         @DisplayName("파트의 시작초가 0보다 작으면 예외가 발생한다.")
@@ -88,7 +88,7 @@ class VotingSongPartTest {
             //given
             //when
             //then
-            assertThatThrownBy(() -> VotingSongPart.forSave(MEMBER, -1, PartLength.SHORT, votingSong))
+            assertThatThrownBy(() -> VotingSongPart.forSave(-1, PartLength.SHORT, votingSong))
                 .isInstanceOf(PartException.StartLessThanZeroException.class);
         }
 
@@ -98,7 +98,7 @@ class VotingSongPartTest {
             //given
             //when
             //then
-            assertThatThrownBy(() -> VotingSongPart.forSave(MEMBER, 30, PartLength.SHORT, votingSong))
+            assertThatThrownBy(() -> VotingSongPart.forSave(30, PartLength.SHORT, votingSong))
                 .isInstanceOf(PartException.StartOverSongLengthException.class);
         }
 
@@ -108,7 +108,7 @@ class VotingSongPartTest {
             //given
             //when
             //then
-            assertThatThrownBy(() -> VotingSongPart.forSave(MEMBER, 29, PartLength.SHORT, votingSong))
+            assertThatThrownBy(() -> VotingSongPart.forSave(29, PartLength.SHORT, votingSong))
                 .isInstanceOf(PartException.EndOverSongLengthException.class);
         }
     }
@@ -121,8 +121,8 @@ class VotingSongPartTest {
         @Test
         void vote_success_one() {
             //given
-            final VotingSongPart part = VotingSongPart.saved(1L, MEMBER, 14, PartLength.SHORT, votingSong);
-            final Vote vote = Vote.saved(1L, part);
+            final VotingSongPart part = VotingSongPart.saved(1L, 14, PartLength.SHORT, votingSong);
+            final Vote vote = Vote.saved(1L, MEMBER, part);
 
             //when
             part.vote(vote);
@@ -135,9 +135,9 @@ class VotingSongPartTest {
         @Test
         void vote_success_many() {
             //given
-            final VotingSongPart part = VotingSongPart.forSave(MEMBER, 14, PartLength.SHORT, votingSong);
-            final Vote firstVote = Vote.forSave(part);
-            final Vote secondVote = Vote.forSave(part);
+            final VotingSongPart part = VotingSongPart.forSave(14, PartLength.SHORT, votingSong);
+            final Vote firstVote = Vote.forSave(MEMBER, part);
+            final Vote secondVote = Vote.forSave(MEMBER, part);
 
             //when
             part.vote(firstVote);
@@ -151,11 +151,11 @@ class VotingSongPartTest {
         @Test
         void vote_fail_voteForOtherPart() {
             //given
-            final VotingSongPart firstPart = VotingSongPart.saved(1L, MEMBER, 14, PartLength.SHORT,
+            final VotingSongPart firstPart = VotingSongPart.saved(1L, 14, PartLength.SHORT,
                 votingSong);
-            final VotingSongPart secondPart = VotingSongPart.saved(2L, MEMBER, 10, PartLength.SHORT,
+            final VotingSongPart secondPart = VotingSongPart.saved(2L, 10, PartLength.SHORT,
                 votingSong);
-            final Vote voteForSecondPart = Vote.forSave(secondPart);
+            final Vote voteForSecondPart = Vote.forSave(MEMBER, secondPart);
 
             //when
             //then
@@ -172,9 +172,9 @@ class VotingSongPartTest {
         @Test
         void getVoteCount_twoVoteDifferentId() {
             //given
-            final VotingSongPart part = VotingSongPart.forSave(MEMBER, 14, PartLength.SHORT, votingSong);
-            final Vote firstVote = Vote.saved(1L, part);
-            final Vote secondVote = Vote.saved(2L, part);
+            final VotingSongPart part = VotingSongPart.forSave(14, PartLength.SHORT, votingSong);
+            final Vote firstVote = Vote.saved(1L, MEMBER, part);
+            final Vote secondVote = Vote.saved(2L, MEMBER, part);
             part.vote(firstVote);
             part.vote(secondVote);
 
@@ -189,9 +189,9 @@ class VotingSongPartTest {
         @Test
         void getVoteCount_towVoteSameId() {
             //given
-            final VotingSongPart part = VotingSongPart.forSave(MEMBER, 14, PartLength.SHORT, votingSong);
-            final Vote firstVote = Vote.saved(1L, part);
-            final Vote secondVote = Vote.saved(1L, part);
+            final VotingSongPart part = VotingSongPart.forSave(14, PartLength.SHORT, votingSong);
+            final Vote firstVote = Vote.saved(1L, MEMBER, part);
+            final Vote secondVote = Vote.saved(1L, MEMBER, part);
             part.vote(firstVote);
 
             //when

--- a/backend/src/test/java/shook/shook/voting_song/domain/VotingSongPartTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/domain/VotingSongPartTest.java
@@ -7,20 +7,22 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import shook.shook.member.domain.Member;
 import shook.shook.part.domain.PartLength;
 import shook.shook.part.exception.PartException;
 import shook.shook.voting_song.exception.VoteException;
 
 class VotingSongPartTest {
 
+    private static Member MEMBER = new Member("a@a.com", "nickname");
     private final VotingSong votingSong = new VotingSong("제목", "비디오ID는 11글자", "이미지URL", "가수", 30);
 
     @DisplayName("Id가 같은 파트는 동등성 비교에 참을 반환한다.")
     @Test
     void equals_true() {
         //given
-        final VotingSongPart firstPart = VotingSongPart.saved(1L, 4, PartLength.SHORT, votingSong);
-        final VotingSongPart secondPart = VotingSongPart.saved(1L, 14, PartLength.SHORT,
+        final VotingSongPart firstPart = VotingSongPart.saved(1L, MEMBER, 4, PartLength.SHORT, votingSong);
+        final VotingSongPart secondPart = VotingSongPart.saved(1L, MEMBER, 14, PartLength.SHORT,
             votingSong);
 
         //when
@@ -39,9 +41,9 @@ class VotingSongPartTest {
         void equals_false_nullId() {
             //given
             final VotingSongPart firstPart =
-                VotingSongPart.saved(null, 4, PartLength.SHORT, votingSong);
+                VotingSongPart.saved(null, MEMBER, 4, PartLength.SHORT, votingSong);
             final VotingSongPart secondPart =
-                VotingSongPart.saved(1L, 14, PartLength.SHORT, votingSong);
+                VotingSongPart.saved(1L, MEMBER, 14, PartLength.SHORT, votingSong);
 
             //when
             final boolean equals = firstPart.equals(secondPart);
@@ -55,9 +57,9 @@ class VotingSongPartTest {
         void equals_false_bothNullId() {
             //given
             final VotingSongPart firstPart =
-                VotingSongPart.saved(null, 4, PartLength.SHORT, votingSong);
+                VotingSongPart.saved(null, MEMBER, 4, PartLength.SHORT, votingSong);
             final VotingSongPart secondPart =
-                VotingSongPart.saved(null, 14, PartLength.SHORT, votingSong);
+                VotingSongPart.saved(null, MEMBER, 14, PartLength.SHORT, votingSong);
 
             //when
             final boolean equals = firstPart.equals(secondPart);
@@ -77,7 +79,7 @@ class VotingSongPartTest {
             //given
             //when
             //then
-            assertDoesNotThrow(() -> VotingSongPart.forSave(14, PartLength.SHORT, votingSong));
+            assertDoesNotThrow(() -> VotingSongPart.forSave(MEMBER, 14, PartLength.SHORT, votingSong));
         }
 
         @DisplayName("파트의 시작초가 0보다 작으면 예외가 발생한다.")
@@ -86,7 +88,7 @@ class VotingSongPartTest {
             //given
             //when
             //then
-            assertThatThrownBy(() -> VotingSongPart.forSave(-1, PartLength.SHORT, votingSong))
+            assertThatThrownBy(() -> VotingSongPart.forSave(MEMBER, -1, PartLength.SHORT, votingSong))
                 .isInstanceOf(PartException.StartLessThanZeroException.class);
         }
 
@@ -96,7 +98,7 @@ class VotingSongPartTest {
             //given
             //when
             //then
-            assertThatThrownBy(() -> VotingSongPart.forSave(30, PartLength.SHORT, votingSong))
+            assertThatThrownBy(() -> VotingSongPart.forSave(MEMBER, 30, PartLength.SHORT, votingSong))
                 .isInstanceOf(PartException.StartOverSongLengthException.class);
         }
 
@@ -106,7 +108,7 @@ class VotingSongPartTest {
             //given
             //when
             //then
-            assertThatThrownBy(() -> VotingSongPart.forSave(29, PartLength.SHORT, votingSong))
+            assertThatThrownBy(() -> VotingSongPart.forSave(MEMBER, 29, PartLength.SHORT, votingSong))
                 .isInstanceOf(PartException.EndOverSongLengthException.class);
         }
     }
@@ -119,7 +121,7 @@ class VotingSongPartTest {
         @Test
         void vote_success_one() {
             //given
-            final VotingSongPart part = VotingSongPart.saved(1L, 14, PartLength.SHORT, votingSong);
+            final VotingSongPart part = VotingSongPart.saved(1L, MEMBER, 14, PartLength.SHORT, votingSong);
             final Vote vote = Vote.saved(1L, part);
 
             //when
@@ -133,7 +135,7 @@ class VotingSongPartTest {
         @Test
         void vote_success_many() {
             //given
-            final VotingSongPart part = VotingSongPart.forSave(14, PartLength.SHORT, votingSong);
+            final VotingSongPart part = VotingSongPart.forSave(MEMBER, 14, PartLength.SHORT, votingSong);
             final Vote firstVote = Vote.forSave(part);
             final Vote secondVote = Vote.forSave(part);
 
@@ -149,9 +151,9 @@ class VotingSongPartTest {
         @Test
         void vote_fail_voteForOtherPart() {
             //given
-            final VotingSongPart firstPart = VotingSongPart.saved(1L, 14, PartLength.SHORT,
+            final VotingSongPart firstPart = VotingSongPart.saved(1L, MEMBER, 14, PartLength.SHORT,
                 votingSong);
-            final VotingSongPart secondPart = VotingSongPart.saved(2L, 10, PartLength.SHORT,
+            final VotingSongPart secondPart = VotingSongPart.saved(2L, MEMBER, 10, PartLength.SHORT,
                 votingSong);
             final Vote voteForSecondPart = Vote.forSave(secondPart);
 
@@ -170,7 +172,7 @@ class VotingSongPartTest {
         @Test
         void getVoteCount_twoVoteDifferentId() {
             //given
-            final VotingSongPart part = VotingSongPart.forSave(14, PartLength.SHORT, votingSong);
+            final VotingSongPart part = VotingSongPart.forSave(MEMBER, 14, PartLength.SHORT, votingSong);
             final Vote firstVote = Vote.saved(1L, part);
             final Vote secondVote = Vote.saved(2L, part);
             part.vote(firstVote);
@@ -187,7 +189,7 @@ class VotingSongPartTest {
         @Test
         void getVoteCount_towVoteSameId() {
             //given
-            final VotingSongPart part = VotingSongPart.forSave(14, PartLength.SHORT, votingSong);
+            final VotingSongPart part = VotingSongPart.forSave(MEMBER, 14, PartLength.SHORT, votingSong);
             final Vote firstVote = Vote.saved(1L, part);
             final Vote secondVote = Vote.saved(1L, part);
             part.vote(firstVote);

--- a/backend/src/test/java/shook/shook/voting_song/domain/VotingSongPartsTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/domain/VotingSongPartsTest.java
@@ -4,18 +4,21 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import shook.shook.member.domain.Member;
 import shook.shook.part.domain.PartLength;
 import shook.shook.part.exception.PartException;
 
 class VotingSongPartsTest {
+    
+    private static Member MEMBER = new Member("a@a.com", "nickname");
 
     @DisplayName("VotingSongParts 를 생성할 때 중복된 파트가 존재하면 예외를 던진다.")
     @Test
     void create_fail_duplicatePartExist() {
         //given
         final VotingSong votingSong = new VotingSong("제목", "비디오ID는 11글자", "이미지URL", "가수", 30);
-        final VotingSongPart firstPart = VotingSongPart.saved(1L, 5, PartLength.SHORT, votingSong);
-        final VotingSongPart secondPart = VotingSongPart.forSave(5, PartLength.SHORT, votingSong);
+        final VotingSongPart firstPart = VotingSongPart.saved(1L, MEMBER, 5, PartLength.SHORT, votingSong);
+        final VotingSongPart secondPart = VotingSongPart.forSave(MEMBER, 5, PartLength.SHORT, votingSong);
 
         final VotingSongParts votingSongParts = new VotingSongParts();
         votingSongParts.addPart(firstPart);

--- a/backend/src/test/java/shook/shook/voting_song/domain/VotingSongPartsTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/domain/VotingSongPartsTest.java
@@ -9,7 +9,7 @@ import shook.shook.part.domain.PartLength;
 import shook.shook.part.exception.PartException;
 
 class VotingSongPartsTest {
-    
+
     private static Member MEMBER = new Member("a@a.com", "nickname");
 
     @DisplayName("VotingSongParts 를 생성할 때 중복된 파트가 존재하면 예외를 던진다.")

--- a/backend/src/test/java/shook/shook/voting_song/domain/VotingSongPartsTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/domain/VotingSongPartsTest.java
@@ -17,8 +17,8 @@ class VotingSongPartsTest {
     void create_fail_duplicatePartExist() {
         //given
         final VotingSong votingSong = new VotingSong("제목", "비디오ID는 11글자", "이미지URL", "가수", 30);
-        final VotingSongPart firstPart = VotingSongPart.saved(1L, MEMBER, 5, PartLength.SHORT, votingSong);
-        final VotingSongPart secondPart = VotingSongPart.forSave(MEMBER, 5, PartLength.SHORT, votingSong);
+        final VotingSongPart firstPart = VotingSongPart.saved(1L, 5, PartLength.SHORT, votingSong);
+        final VotingSongPart secondPart = VotingSongPart.forSave(5, PartLength.SHORT, votingSong);
 
         final VotingSongParts votingSongParts = new VotingSongParts();
         votingSongParts.addPart(firstPart);

--- a/backend/src/test/java/shook/shook/voting_song/domain/VotingSongTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/domain/VotingSongTest.java
@@ -5,21 +5,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import shook.shook.member.domain.Member;
 import shook.shook.part.domain.PartLength;
 import shook.shook.voting_song.exception.VotingSongPartException;
 
 class VotingSongTest {
-
-    private static Member MEMBER = new Member("a@a.com", "nickname");
 
     @DisplayName("파트 수집 중인 노래에 파트를 등록한다. ( 노래에 해당하는 파트일 때 )")
     @Test
     void addPart_valid() {
         //given
         final VotingSong votingSong = new VotingSong("노래제목", "비디오ID는 11글자", "이미지URL", "가수", 180);
-        final VotingSongPart votingSongPart =
-            VotingSongPart.forSave(MEMBER, 1, PartLength.STANDARD, votingSong);
+        final VotingSongPart votingSongPart = VotingSongPart.forSave(1, PartLength.STANDARD, votingSong);
 
         //when
         votingSong.addPart(votingSongPart);
@@ -34,8 +30,7 @@ class VotingSongTest {
         //given
         final VotingSong firstSong = new VotingSong("노래제목", "비디오ID는 11글자", "이미지URL", "가수", 180);
         final VotingSong secondSong = new VotingSong("노래제목", "비디오ID는 11글자", "이미지URL", "가수", 180);
-        final VotingSongPart partInSecondSong =
-            VotingSongPart.forSave(MEMBER, 1, PartLength.STANDARD, secondSong);
+        final VotingSongPart partInSecondSong = VotingSongPart.forSave(1, PartLength.STANDARD, secondSong);
 
         //when
         //then

--- a/backend/src/test/java/shook/shook/voting_song/domain/VotingSongTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/domain/VotingSongTest.java
@@ -5,10 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import shook.shook.member.domain.Member;
 import shook.shook.part.domain.PartLength;
 import shook.shook.voting_song.exception.VotingSongPartException;
 
 class VotingSongTest {
+
+    private static Member MEMBER = new Member("a@a.com", "nickname");
 
     @DisplayName("파트 수집 중인 노래에 파트를 등록한다. ( 노래에 해당하는 파트일 때 )")
     @Test
@@ -16,7 +19,7 @@ class VotingSongTest {
         //given
         final VotingSong votingSong = new VotingSong("노래제목", "비디오ID는 11글자", "이미지URL", "가수", 180);
         final VotingSongPart votingSongPart =
-            VotingSongPart.forSave(1, PartLength.STANDARD, votingSong);
+            VotingSongPart.forSave(MEMBER, 1, PartLength.STANDARD, votingSong);
 
         //when
         votingSong.addPart(votingSongPart);
@@ -32,7 +35,7 @@ class VotingSongTest {
         final VotingSong firstSong = new VotingSong("노래제목", "비디오ID는 11글자", "이미지URL", "가수", 180);
         final VotingSong secondSong = new VotingSong("노래제목", "비디오ID는 11글자", "이미지URL", "가수", 180);
         final VotingSongPart partInSecondSong =
-            VotingSongPart.forSave(1, PartLength.STANDARD, secondSong);
+            VotingSongPart.forSave(MEMBER, 1, PartLength.STANDARD, secondSong);
 
         //when
         //then

--- a/backend/src/test/java/shook/shook/voting_song/domain/repository/VoteRepositoryTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/domain/repository/VoteRepositoryTest.java
@@ -1,0 +1,48 @@
+package shook.shook.voting_song.domain.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+import shook.shook.member.domain.Member;
+import shook.shook.member.domain.repository.MemberRepository;
+import shook.shook.part.domain.PartLength;
+import shook.shook.support.UsingJpaTest;
+import shook.shook.voting_song.domain.Vote;
+import shook.shook.voting_song.domain.VotingSong;
+import shook.shook.voting_song.domain.VotingSongPart;
+
+@Sql("classpath:/killingpart/initialize_killing_part_song.sql")
+class VoteRepositoryTest extends UsingJpaTest {
+
+    @Autowired
+    private VoteRepository voteRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private VotingSongRepository votingSongRepository;
+
+    @Autowired
+    private VotingSongPartRepository votingSongPartRepository;
+
+    @DisplayName("투표중인 노래의 파트에 멤버의 투표가 존재하는지 반환한다.")
+    @Test
+    void existsByMemberAndVotingSongPart() {
+        //given
+        final Member member = memberRepository.findById(1L).get();
+        final VotingSong votingSong = votingSongRepository.save(
+            new VotingSong("제목1", "비디오ID는 11글자", "이미지URL", "가수", 20));
+        final VotingSongPart votingSongPart = votingSongPartRepository.save(
+            VotingSongPart.forSave(1, PartLength.SHORT, votingSong));
+        voteRepository.save(Vote.forSave(member, votingSongPart));
+
+        //when
+        final boolean isVoteExist = voteRepository.existsByMemberAndVotingSongPart(member, votingSongPart);
+
+        //then
+        Assertions.assertThat(isVoteExist).isTrue();
+    }
+}

--- a/backend/src/test/java/shook/shook/voting_song/domain/repository/VoteRepositoryTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/domain/repository/VoteRepositoryTest.java
@@ -1,6 +1,7 @@
 package shook.shook.voting_song.domain.repository;
 
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +44,6 @@ class VoteRepositoryTest extends UsingJpaTest {
         final boolean isVoteExist = voteRepository.existsByMemberAndVotingSongPart(member, votingSongPart);
 
         //then
-        Assertions.assertThat(isVoteExist).isTrue();
+        assertThat(isVoteExist).isTrue();
     }
 }

--- a/backend/src/test/java/shook/shook/voting_song/domain/repository/VotingSongPartRepositoryTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/domain/repository/VotingSongPartRepositoryTest.java
@@ -23,7 +23,8 @@ class VotingSongPartRepositoryTest extends UsingJpaTest {
 
     @Autowired
     private VotingSongRepository votingSongRepository;
-    private static VotingSong SAVED_SONG;
+    
+    private VotingSong SAVED_SONG;
 
     @BeforeEach
     void setUp() {

--- a/backend/src/test/java/shook/shook/voting_song/domain/repository/VotingSongPartRepositoryTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/domain/repository/VotingSongPartRepositoryTest.java
@@ -5,13 +5,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import shook.shook.member.domain.Member;
-import shook.shook.member.domain.repository.MemberRepository;
 import shook.shook.part.domain.PartLength;
 import shook.shook.support.UsingJpaTest;
 import shook.shook.voting_song.domain.VotingSong;
@@ -19,21 +18,15 @@ import shook.shook.voting_song.domain.VotingSongPart;
 
 class VotingSongPartRepositoryTest extends UsingJpaTest {
 
-    private static VotingSong SAVED_SONG;
-    private static Member MEMBER;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
     @Autowired
     private VotingSongPartRepository votingSongPartRepository;
 
     @Autowired
     private VotingSongRepository votingSongRepository;
+    private static VotingSong SAVED_SONG;
 
     @BeforeEach
     void setUp() {
-        MEMBER = memberRepository.save(new Member("a@a.com", "nickname"));
         SAVED_SONG = votingSongRepository.save(
             new VotingSong("제목", "비디오ID는 11글자", "이미지URL", "가수", 30));
     }
@@ -42,7 +35,7 @@ class VotingSongPartRepositoryTest extends UsingJpaTest {
     @Test
     void save() {
         //given
-        final VotingSongPart votingSongPart = VotingSongPart.forSave(MEMBER, 14, PartLength.SHORT, SAVED_SONG);
+        final VotingSongPart votingSongPart = VotingSongPart.forSave(14, PartLength.SHORT, SAVED_SONG);
 
         //when
         final VotingSongPart saved = votingSongPartRepository.save(votingSongPart);
@@ -56,7 +49,7 @@ class VotingSongPartRepositoryTest extends UsingJpaTest {
     @Test
     void createdAt() {
         //given
-        final VotingSongPart votingSongPart = VotingSongPart.forSave(MEMBER, 14, PartLength.SHORT, SAVED_SONG);
+        final VotingSongPart votingSongPart = VotingSongPart.forSave(14, PartLength.SHORT, SAVED_SONG);
 
         //when
         final LocalDateTime prev = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
@@ -72,8 +65,8 @@ class VotingSongPartRepositoryTest extends UsingJpaTest {
     @Test
     void findAllBySong() {
         //given
-        final VotingSongPart firstPart = VotingSongPart.forSave(MEMBER, 1, PartLength.SHORT, SAVED_SONG);
-        final VotingSongPart secondPart = VotingSongPart.forSave(MEMBER, 5, PartLength.SHORT, SAVED_SONG);
+        final VotingSongPart firstPart = VotingSongPart.forSave(1, PartLength.SHORT, SAVED_SONG);
+        final VotingSongPart secondPart = VotingSongPart.forSave(5, PartLength.SHORT, SAVED_SONG);
         votingSongPartRepository.save(firstPart);
         votingSongPartRepository.save(secondPart);
 
@@ -93,7 +86,7 @@ class VotingSongPartRepositoryTest extends UsingJpaTest {
         @Test
         void findOnePart() {
             // given
-            final VotingSongPart part = VotingSongPart.forSave(MEMBER, 1, PartLength.SHORT, SAVED_SONG);
+            final VotingSongPart part = VotingSongPart.forSave(1, PartLength.SHORT, SAVED_SONG);
             votingSongPartRepository.save(part);
 
             // when
@@ -118,19 +111,18 @@ class VotingSongPartRepositoryTest extends UsingJpaTest {
     @Test
     void existsByVotingSongAndMemberAndStartSecondAndLength() {
         //given
-        final VotingSongPart part = VotingSongPart.forSave(MEMBER, 1, PartLength.SHORT, SAVED_SONG);
+        final VotingSongPart part = VotingSongPart.forSave(1, PartLength.SHORT, SAVED_SONG);
         votingSongPartRepository.save(part);
 
         //when
         saveAndClearEntityManager();
-        final boolean isMemberSamePartExist = votingSongPartRepository.existsByVotingSongAndMemberAndStartSecondAndLength(
-            part.getVotingSong(),
-            part.getMember(),
+        final Optional<VotingSongPart> findVotingSongPart = votingSongPartRepository.findByVotingSongAndStartSecondAndLength(
+            SAVED_SONG,
             part.getStartSecond(),
             part.getLength()
         );
 
         //then
-        assertThat(isMemberSamePartExist).isTrue();
+        assertThat(findVotingSongPart).isPresent();
     }
 }

--- a/backend/src/test/java/shook/shook/voting_song/ui/VotingSongPartControllerTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/ui/VotingSongPartControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.jdbc.Sql;
 import shook.shook.auth.application.TokenProvider;
@@ -58,8 +59,8 @@ class VotingSongPartControllerTest {
         RestAssured.given().log().all()
             .contentType(ContentType.JSON)
             .body(request)
-            .header("Authorization", "Bearer " + accessToken)
-            .when().log().all().post("/voting-songs/" + votingSong.getId() + "/parts")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+            .when().log().all().post("/voting-songs/{songId}/parts", votingSong.getId())
             .then().statusCode(HttpStatus.CREATED.value());
     }
 
@@ -78,8 +79,8 @@ class VotingSongPartControllerTest {
         RestAssured.given().log().all()
             .contentType(ContentType.JSON)
             .body(request)
-            .header("Authorization", "Bearer " + accessToken)
-            .when().log().all().post("/voting-songs/" + votingSong.getId() + "/parts")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+            .when().log().all().post("/voting-songs/{songId}/parts", votingSong.getId())
             .then().statusCode(HttpStatus.OK.value());
     }
 

--- a/backend/src/test/java/shook/shook/voting_song/ui/VotingSongPartControllerTest.java
+++ b/backend/src/test/java/shook/shook/voting_song/ui/VotingSongPartControllerTest.java
@@ -1,0 +1,102 @@
+package shook.shook.voting_song.ui;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.jdbc.Sql;
+import shook.shook.auth.application.TokenProvider;
+import shook.shook.member.domain.Member;
+import shook.shook.member.domain.repository.MemberRepository;
+import shook.shook.part.domain.PartLength;
+import shook.shook.voting_song.application.dto.VotingSongPartRegisterRequest;
+import shook.shook.voting_song.domain.VotingSong;
+import shook.shook.voting_song.domain.VotingSongPart;
+import shook.shook.voting_song.domain.repository.VotingSongPartRepository;
+import shook.shook.voting_song.domain.repository.VotingSongRepository;
+
+@Sql("classpath:/killingpart/initialize_killing_part_song.sql")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class VotingSongPartControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private VotingSongRepository votingSongRepository;
+
+    @Autowired
+    private VotingSongPartRepository votingSongPartRepository;
+
+    @DisplayName("투표중인 노래에 파트를 등록 성공시 201 상태코드를 반환한다.")
+    @Test
+    void registerPart() {
+        //given
+        final VotingSong votingSong = getSavedSong();
+        final String accessToken = getToken(1L, "nickname");
+        final VotingSongPartRegisterRequest request = new VotingSongPartRegisterRequest(1, 10);
+
+        //when
+        //then
+        RestAssured.given().log().all()
+            .contentType(ContentType.JSON)
+            .body(request)
+            .header("Authorization", "Bearer " + accessToken)
+            .when().log().all().post("/voting-songs/" + votingSong.getId() + "/parts")
+            .then().statusCode(HttpStatus.CREATED.value());
+    }
+
+    @DisplayName("멤버가 똑같은 파트를 등록한 경우 200 상태코드를 반환한다.")
+    @Test
+    void registerPart_whenMemberSamePartExist() {
+        //given
+        final VotingSong votingSong = getSavedSong();
+        final String accessToken = getToken(1L, "nickname");
+        final Member member = getMember();
+        final VotingSongPartRegisterRequest request = new VotingSongPartRegisterRequest(1, 10);
+        addPart(votingSong, member, request);
+
+        //when
+        //then
+        RestAssured.given().log().all()
+            .contentType(ContentType.JSON)
+            .body(request)
+            .header("Authorization", "Bearer " + accessToken)
+            .when().log().all().post("/voting-songs/" + votingSong.getId() + "/parts")
+            .then().statusCode(HttpStatus.OK.value());
+    }
+
+    private String getToken(final Long memberId, final String nickname) {
+        return tokenProvider.createAccessToken(memberId, nickname);
+    }
+
+    private VotingSong getSavedSong() {
+        return votingSongRepository.save(new VotingSong("title", "12345678901", "albumCover", "singer", 100));
+    }
+
+    private Member getMember() {
+        return memberRepository.findById(1L).orElseThrow(RuntimeException::new);
+    }
+
+    private void addPart(final VotingSong song, final Member member, final VotingSongPartRegisterRequest request) {
+        final PartLength length = PartLength.findBySecond(request.getLength());
+        votingSongPartRepository.save(VotingSongPart.forSave(member, request.getStartSecond(), length, song));
+    }
+}

--- a/backend/src/test/resources/schema-test.sql
+++ b/backend/src/test/resources/schema-test.sql
@@ -72,6 +72,7 @@ create table if not exists voting_song_part
     start_second   integer      not null,
     length         varchar(255) not null check (length in ('SHORT', 'STANDARD', 'LONG')),
     voting_song_id bigint       not null,
+    member_id      bigint       not null,
     created_at     timestamp(6) not null,
     primary key (id)
 );

--- a/backend/src/test/resources/schema-test.sql
+++ b/backend/src/test/resources/schema-test.sql
@@ -72,7 +72,6 @@ create table if not exists voting_song_part
     start_second   integer      not null,
     length         varchar(255) not null check (length in ('SHORT', 'STANDARD', 'LONG')),
     voting_song_id bigint       not null,
-    member_id      bigint       not null,
     created_at     timestamp(6) not null,
     primary key (id)
 );
@@ -80,6 +79,7 @@ create table if not exists vote
 (
     id                  bigint auto_increment,
     voting_song_part_id bigint       not null,
+    member_id           bigint       not null,
     created_at          timestamp(6) not null,
     primary key (id)
 );


### PR DESCRIPTION
## 📝작업 내용

VotingSong -> VotingSongParts -> Member 로의 많은 N+1 쿼리가 예상되기에

```java
boolean existsByVotingSongAndMemberAndStartSecondAndLength(final VotingSong votingSong,
                                                               final Member member,
                                                               final int startSecond,
                                                               final PartLength length);
```

해당 메서드를 사용해서 확인했습니다.😊

## 💬리뷰 참고사항

추후에 해당 쿼리에 대한 분석과 인덱스 적용 여부에 대해서 파악해야 됩니다!!😁

멤버가 같은 파트를 등록했을 때는 200(OK), 아닌 경우에는 201(CREATED) 를 사용해서 클라이언트에게 전달하려 했으나 이 부분에 대해서 추후 프론트 팀원들과의 논의가 필요할 것 같습니다!!🫡

## #️⃣연관된 이슈

close #461 


