### PR TITLE
Feat/#462 닉네임 변경 API 구현

### DIFF
--- a/backend/src/main/java/shook/shook/auth/application/AuthService.java
+++ b/backend/src/main/java/shook/shook/auth/application/AuthService.java
@@ -36,7 +36,7 @@ public class AuthService {
     }
 
     public ReissueAccessTokenResponse reissueAccessTokenByRefreshToken(final String refreshToken,
-                                                                       final String accessToken) {
+        final String accessToken) {
         final Claims claims = tokenProvider.parseClaims(refreshToken);
         final Long memberId = claims.get("memberId", Long.class);
         final String nickname = claims.get("nickname", String.class);

--- a/backend/src/main/java/shook/shook/auth/config/AuthConfig.java
+++ b/backend/src/main/java/shook/shook/auth/config/AuthConfig.java
@@ -20,8 +20,8 @@ public class AuthConfig implements WebMvcConfigurer {
     private final TokenInterceptor tokenInterceptor;
 
     public AuthConfig(final AuthArgumentResolver authArgumentResolver,
-                      final LoginCheckerInterceptor loginCheckerInterceptor,
-                      final TokenInterceptor tokenInterceptor
+        final LoginCheckerInterceptor loginCheckerInterceptor,
+        final TokenInterceptor tokenInterceptor
     ) {
         this.authArgumentResolver = authArgumentResolver;
         this.loginCheckerInterceptor = loginCheckerInterceptor;
@@ -45,7 +45,8 @@ public class AuthConfig implements WebMvcConfigurer {
             .includePathPattern("/songs/*/parts/*/likes", PathMethod.PUT)
             .includePathPattern("/voting-songs/*/parts", PathMethod.POST)
             .includePathPattern("/songs/*/parts/*/comments", PathMethod.POST)
-            .includePathPattern("/members/*", PathMethod.DELETE);
+            .includePathPattern("/members/*", PathMethod.DELETE)
+            .includePathPattern("/members/*/nickname", PathMethod.PATCH);
     }
 
     @Override

--- a/backend/src/main/java/shook/shook/auth/ui/AuthController.java
+++ b/backend/src/main/java/shook/shook/auth/ui/AuthController.java
@@ -30,6 +30,7 @@ public class AuthController implements AuthApi {
         final Cookie cookie = cookieProvider.createRefreshTokenCookie(tokenPair.getRefreshToken());
         response.addCookie(cookie);
         final LoginResponse loginResponse = new LoginResponse(tokenPair.getAccessToken());
+
         return ResponseEntity.ok(loginResponse);
     }
 }

--- a/backend/src/main/java/shook/shook/globalexception/ErrorCode.java
+++ b/backend/src/main/java/shook/shook/globalexception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     NOT_FOUND_OAUTH(1010, "현재 지원하지 않는 OAuth 요청입니다."),
     INVALID_REFRESH_TOKEN(1011, "존재하지 않는 refreshToken 입니다."),
     TOKEN_PAIR_NOT_MATCHING_EXCEPTION(1012, "올바르지 않은 TokenPair 입니다."),
+    ALREADY_EXIST_NICKNAME(1013, "존재하는 닉네임입니다."),
 
     // 2000: 킬링파트 - 좋아요, 댓글
 
@@ -60,7 +61,7 @@ public enum ErrorCode {
     VOTING_PART_END_OVER_SONG_LENGTH(4003, "파트의 끝 초는 노래 길이를 초과할 수 없습니다."),
     INVALID_VOTING_PART_LENGTH(4004, "파트의 길이는 5, 10, 15초 중 하나여야합니다."),
     VOTING_PART_DUPLICATE_START_AND_LENGTH_EXCEPTION(4005,
-        "한 노래에 동일한 파트를 두 개 이상 등록할 수 없습니다."),
+                                                     "한 노래에 동일한 파트를 두 개 이상 등록할 수 없습니다."),
     VOTING_SONG_PART_NOT_EXIST(4006, "투표 대상 파트가 존재하지 않습니다."),
 
     VOTING_SONG_PART_FOR_OTHER_SONG(4007, "해당 파트는 다른 노래의 파트입니다."),

--- a/backend/src/main/java/shook/shook/member/application/MemberService.java
+++ b/backend/src/main/java/shook/shook/member/application/MemberService.java
@@ -100,6 +100,7 @@ public class MemberService {
         }
     }
 
+    @Transactional
     public TokenPair updateNickname(final Long memberId, final MemberInfo memberInfo,
         final NicknameUpdateRequest request) {
         final Member member = getMemberIfValidRequest(memberId, memberInfo);

--- a/backend/src/main/java/shook/shook/member/application/dto/NicknameUpdateRequest.java
+++ b/backend/src/main/java/shook/shook/member/application/dto/NicknameUpdateRequest.java
@@ -1,0 +1,18 @@
+package shook.shook.member.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "닉네임 변경 요청")
+@AllArgsConstructor
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+@Getter
+public class NicknameUpdateRequest {
+
+    @Schema(description = "닉네임", example = "shookshook")
+    @NotBlank
+    private String nickname;
+}

--- a/backend/src/main/java/shook/shook/member/application/dto/NicknameUpdateRequest.java
+++ b/backend/src/main/java/shook/shook/member/application/dto/NicknameUpdateRequest.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Schema(description = "닉네임 변경 요청")
-@AllArgsConstructor
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Getter
 public class NicknameUpdateRequest {
 

--- a/backend/src/main/java/shook/shook/member/domain/Member.java
+++ b/backend/src/main/java/shook/shook/member/domain/Member.java
@@ -49,6 +49,10 @@ public class Member {
         this.nickname = new Nickname(newNickName);
     }
 
+    public void updateNickname(final Nickname newNickname) {
+        this.nickname = newNickname;
+    }
+
     public String getEmail() {
         return email.getValue();
     }

--- a/backend/src/main/java/shook/shook/member/domain/Nickname.java
+++ b/backend/src/main/java/shook/shook/member/domain/Nickname.java
@@ -16,7 +16,7 @@ import shook.shook.util.StringChecker;
 @Embeddable
 public class Nickname {
 
-    private static final int NICKNAME_MAXIMUM_LENGTH = 100;
+    private static final int NICKNAME_MAXIMUM_LENGTH = 20;
 
     @Column(name = "nickname", length = NICKNAME_MAXIMUM_LENGTH, nullable = false)
     private String value;

--- a/backend/src/main/java/shook/shook/member/domain/repository/MemberRepository.java
+++ b/backend/src/main/java/shook/shook/member/domain/repository/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(final Email email);
 
     Optional<Member> findByIdAndNickname(final Long id, final Nickname nickname);
+
+    boolean existsMemberByNickname(final Nickname nickname);
 }

--- a/backend/src/main/java/shook/shook/member/exception/MemberException.java
+++ b/backend/src/main/java/shook/shook/member/exception/MemberException.java
@@ -93,4 +93,15 @@ public class MemberException extends CustomException {
             super(ErrorCode.MEMBER_NOT_EXIST, inputValuesByProperty);
         }
     }
+
+    public static class ExistNicknameException extends MemberException {
+
+        public ExistNicknameException() {
+            super(ErrorCode.ALREADY_EXIST_NICKNAME);
+        }
+
+        public ExistNicknameException(final Map<String, String> inputValuesByProperty) {
+            super(ErrorCode.ALREADY_EXIST_NICKNAME, inputValuesByProperty);
+        }
+    }
 }

--- a/backend/src/main/java/shook/shook/member/ui/MemberController.java
+++ b/backend/src/main/java/shook/shook/member/ui/MemberController.java
@@ -1,15 +1,23 @@
 package shook.shook.member.ui;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import shook.shook.auth.application.dto.ReissueAccessTokenResponse;
+import shook.shook.auth.application.dto.TokenPair;
+import shook.shook.auth.ui.CookieProvider;
 import shook.shook.auth.ui.argumentresolver.Authenticated;
 import shook.shook.auth.ui.argumentresolver.MemberInfo;
 import shook.shook.member.application.MemberService;
+import shook.shook.member.application.dto.NicknameUpdateRequest;
 import shook.shook.member.ui.openapi.MemberApi;
 
 @RequiredArgsConstructor
@@ -18,6 +26,7 @@ import shook.shook.member.ui.openapi.MemberApi;
 public class MemberController implements MemberApi {
 
     private final MemberService memberService;
+    private final CookieProvider cookieProvider;
 
     @DeleteMapping
     public ResponseEntity<Void> deleteMember(
@@ -27,5 +36,26 @@ public class MemberController implements MemberApi {
         memberService.deleteById(memberId, memberInfo);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @PatchMapping("/nickname")
+    public ResponseEntity<ReissueAccessTokenResponse> updateNickname(
+        @PathVariable(name = "member_id") final Long memberId,
+        @Authenticated final MemberInfo memberInfo,
+        @RequestBody final NicknameUpdateRequest request,
+        final HttpServletResponse response
+    ) {
+        final TokenPair tokenPair = memberService.updateNickname(memberId, memberInfo, request);
+
+        if (tokenPair == null) {
+            return ResponseEntity.noContent().build();
+        }
+
+        final Cookie cookie = cookieProvider.createRefreshTokenCookie(tokenPair.getRefreshToken());
+        response.addCookie(cookie);
+        final ReissueAccessTokenResponse reissueResponse = new ReissueAccessTokenResponse(
+            tokenPair.getAccessToken());
+
+        return ResponseEntity.ok(reissueResponse);
     }
 }

--- a/backend/src/main/java/shook/shook/member/ui/openapi/MemberApi.java
+++ b/backend/src/main/java/shook/shook/member/ui/openapi/MemberApi.java
@@ -2,13 +2,20 @@ package shook.shook.member.ui.openapi;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import shook.shook.auth.application.dto.ReissueAccessTokenResponse;
 import shook.shook.auth.ui.argumentresolver.Authenticated;
 import shook.shook.auth.ui.argumentresolver.MemberInfo;
+import shook.shook.member.application.dto.NicknameUpdateRequest;
 
 @Tag(name = "Member", description = "회원 관리 API")
 public interface MemberApi {
@@ -30,5 +37,47 @@ public interface MemberApi {
     ResponseEntity<Void> deleteMember(
         @PathVariable(name = "member_id") final Long memberId,
         @Authenticated final MemberInfo memberInfo
+    );
+
+    @Operation(
+        summary = "닉네임 변경",
+        description = "닉네임을 변경한다."
+    )
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "닉네임 변경 성공"
+            ),
+            @ApiResponse(
+                responseCode = "204",
+                description = "동일한 닉네임으로 변경하여 변경된 닉네임이 없음"
+            ),
+            @ApiResponse(
+                responseCode = "400",
+                description = "중복된 닉네임, 20자가 넘는 닉네임, 공백 닉네임의 이유로 닉네임 변경 실패"
+            )
+        }
+    )
+    @Parameters(
+        value = {
+            @Parameter(
+                name = "member_id",
+                description = "닉네임을 변경할 회원 id",
+                required = true
+            ),
+            @Parameter(
+                name = "nickname",
+                description = "변경할 닉네임",
+                required = true
+            )
+        }
+    )
+    @PatchMapping("/nickname")
+    ResponseEntity<ReissueAccessTokenResponse> updateNickname(
+        @PathVariable(name = "member_id") final Long memberId,
+        @Authenticated final MemberInfo memberInfo,
+        @RequestBody final NicknameUpdateRequest request,
+        final HttpServletResponse response
     );
 }

--- a/backend/src/test/java/shook/shook/member/domain/NicknameTest.java
+++ b/backend/src/test/java/shook/shook/member/domain/NicknameTest.java
@@ -33,9 +33,9 @@ class NicknameTest {
             .isInstanceOf(MemberException.NullOrEmptyNicknameException.class);
     }
 
-    @DisplayName("닉네임의 길이가 100자를 넘을 경우 예외를 던진다.")
+    @DisplayName("닉네임의 길이가 20자를 넘을 경우 예외를 던진다.")
     @Test
-    void create_fail_lengthOver100() {
+    void create_fail_lengthOver20() {
         //given
         final String nickname = ".".repeat(101);
 


### PR DESCRIPTION
## 📝작업 내용

닉네임 변경 API를 구현한다.

## 💬리뷰 참고사항

- 닉네임이 토큰 발행 시 필요하기 때문에, 기존에 존재하던 토큰을 없애고 토큰을 추가하는 것이 맞지만 현재는 기존 토큰을 없애지 않고 새로 발행된 토큰과 accessToken 을 추가하는 것으로 했습니다.
- 동일한 닉네임으로 변경하려 하는 경우, 토큰을 전달하면 안 되기 때문에 TokenPair 를 null 로 반환했습니다. TokenPair 가 null 인 경우 204 상태코드를 반환합니다.
- 중복 닉네임, 공백 닉네임을 Bad Request 로 간주했습니다.
- reissueTokenPair 가 MemberService 에 존재하는 이유는 AuthService 에 MemberService 가 이미 존재하여 MemberService 에서 AuthService 의존이 생기면 순환 참조가 발생하기 때문입니다. 

## #️⃣연관된 이슈

closes #462


