### PR TITLE
Fix/#452 좋아요한 킬링파트 공유 링크에 변경된 라우터 경로 적용

### DIFF
--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -205,7 +205,7 @@ const LikePartItem = ({ songId, albumCoverUrl, title, singer, start, end }: Like
       memberId: user?.memberId,
     });
 
-    copyClipboard(`${BASE_URL?.replace('/api', '')}/songs/${songId}`);
+    copyClipboard(`${BASE_URL?.replace('/api', '')}/songs/${songId}/ALL`);
     showToast('클립보드에 영상링크가 복사되었습니다.');
   };
 


### PR DESCRIPTION
## 📝작업 내용

 좋아요한 킬링파트 공유 링크에 변경된 라우터 경로 적용

## 💬리뷰 참고사항

라우터 경로에 맞게 `/ALL` 을 붙여주었습니다. 
운영 서버에 에러가 나고 있는 상황이라 바로 머지 하려고 합니다.

해당 링크 공유 경로가 env 파일의 BASE_URL 기준으로 적용되어 있더라고요
이 부분을 replace 함수를 사용하여 'api' 부분만 제거하는식으로 사용되고 있는데 추가적인 환경변수를 만드는게 어떨까 싶네요


@cruelladevil 에게 
팀원 전체 밤샘 이슈로 미처 하지 못했던 리뷰를 남겨봅니다.

1. 해당 페이지 컴포넌트에 다른 하위 컴포넌트가 존재하더라고요 분리해 주시면 좋겠습니다.
2. 랜덤 노랫말 계산 로직이 jsx return문 내부에 있어서 다소 복잡한 감이 있는것 같아요 이 부분 분리되면 좋을 것 같아요.
3. like 불러오는 api 함수를 예전에 대화나눴던 대로 적당한 네이밍과 함께 features/SomeComponent/remote 하위에 함수로 분리해주면 감사하겠습니다~
4. 코난 작업 범위중에 위 3번 처럼 api 함수 분리 안된 부분이 있다면 같이 수정되면 좋을 것 같아요~


## #️⃣연관된 이슈

#452 


