### PR TITLE
Hotfix/#483 마이페이지에서 좋아요한 노래 아이템 클릭시 노래 듣기로 이동

### DIFF
--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -197,8 +197,10 @@ type LikePartItemProps = LikeKillingPart & {
 const LikePartItem = ({ songId, albumCoverUrl, title, singer, start, end }: LikePartItemProps) => {
   const { showToast } = useToastContext();
   const { user } = useAuthContext();
+  const navigate = useNavigate();
 
-  const shareUrl = () => {
+  const shareUrl: React.MouseEventHandler = (e) => {
+    e.stopPropagation();
     sendGAEvent({
       action: GA_ACTIONS.COPY_URL,
       category: GA_CATEGORIES.MY_PAGE,
@@ -209,11 +211,15 @@ const LikePartItem = ({ songId, albumCoverUrl, title, singer, start, end }: Like
     showToast('클립보드에 영상링크가 복사되었습니다.');
   };
 
+  const goToListenSong = () => {
+    navigate(`/songs/${songId}/ALL`);
+  };
+
   const { minute: startMin, second: startSec } = secondsToMinSec(start);
   const { minute: endMin, second: endSec } = secondsToMinSec(end);
 
   return (
-    <Grid>
+    <Grid onClick={goToListenSong}>
       <Thumbnail src={albumCoverUrl} alt={`${title}-${singer}`} />
       <SongTitle>{title}</SongTitle>
       <Singer>{singer}</Singer>

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -241,7 +241,7 @@ const LikePartItem = ({ songId, albumCoverUrl, title, singer, start, end }: Like
   );
 };
 
-const Grid = styled.div`
+const Grid = styled.button`
   display: grid;
   grid-template:
     'thumbnail title _' 26px
@@ -250,9 +250,11 @@ const Grid = styled.div`
     / 70px auto 26px;
   column-gap: 8px;
 
+  width: 100%;
   padding: 6px 0;
 
   color: ${({ theme: { color } }) => color.white};
+  text-align: start;
 `;
 
 const SongTitle = styled.div`


### PR DESCRIPTION
## 📝작업 내용

- 마이페이지에서 좋아요한 노래 아이템 클릭시 노래 듣기로 이동
- 카테고리는 ALL입니다.

## 💬리뷰 참고사항
급하게 반영할 사항이라 merge 하겠습니다. 수정된 부분은 극히 적어요!


## #️⃣연관된 이슈
close #483


