### PR TITLE
Feat/#515 캐러셀용 최신 노래 조회 API 구현

### DIFF
--- a/backend/src/main/java/shook/shook/song/application/SongService.java
+++ b/backend/src/main/java/shook/shook/song/application/SongService.java
@@ -3,6 +3,7 @@ package shook.shook.song.application;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -11,6 +12,7 @@ import shook.shook.auth.ui.argumentresolver.MemberInfo;
 import shook.shook.member.domain.Member;
 import shook.shook.member.domain.repository.MemberRepository;
 import shook.shook.member.exception.MemberException;
+import shook.shook.song.application.dto.RecentSongCarouselResponse;
 import shook.shook.song.application.dto.SongResponse;
 import shook.shook.song.application.dto.SongSwipeResponse;
 import shook.shook.song.application.dto.SongWithKillingPartsRegisterRequest;
@@ -200,5 +202,13 @@ public class SongService {
         final List<Song> nextSongs = inMemorySongs.getNextLikedSongByGenre(currentSong, genre, AFTER_SONGS_COUNT);
 
         return convertToSongResponses(memberInfo, nextSongs);
+    }
+
+    public List<RecentSongCarouselResponse> findRecentRegisteredSongsForCarousel(final Integer size) {
+        final List<Song> topSongs = songRepository.findSongsOrderById(PageRequest.of(0, size));
+
+        return topSongs.stream()
+            .map(RecentSongCarouselResponse::from)
+            .toList();
     }
 }

--- a/backend/src/main/java/shook/shook/song/application/dto/RecentSongCarouselResponse.java
+++ b/backend/src/main/java/shook/shook/song/application/dto/RecentSongCarouselResponse.java
@@ -1,0 +1,37 @@
+package shook.shook.song.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import shook.shook.song.domain.Song;
+
+@Schema(description = "캐러셀에 보여질 최근 노래 응답")
+@AllArgsConstructor
+@Getter
+public class RecentSongCarouselResponse {
+
+    @Schema(description = "노래 id", example = "1")
+    private final Long id;
+
+    @Schema(description = "노래 제목", example = "노래제목")
+    private final String title;
+
+    @Schema(description = "가수 이름", example = "가수")
+    private final String singer;
+
+    @Schema(description = "비디오 영상 길이", example = "274")
+    private final int videoLength;
+
+    @Schema(description = "앨범 자켓 이미지 url", example = "https://image.com/album_cover.jpg")
+    private final String albumCoverUrl;
+
+    public static RecentSongCarouselResponse from(final Song song) {
+        return new RecentSongCarouselResponse(
+            song.getId(),
+            song.getTitle(),
+            song.getSinger(),
+            song.getLength(),
+            song.getAlbumCoverUrl()
+        );
+    }
+}

--- a/backend/src/main/java/shook/shook/song/domain/repository/SongRepository.java
+++ b/backend/src/main/java/shook/shook/song/domain/repository/SongRepository.java
@@ -46,5 +46,8 @@ public interface SongRepository extends JpaRepository<Song, Long> {
         final Pageable pageable
     );
 
+    @Query("SELECT s from Song s ORDER BY s.id DESC")
+    List<Song> findSongsOrderById(final Pageable pageable);
+
     boolean existsSongByTitle(final SongTitle title);
 }

--- a/backend/src/main/java/shook/shook/song/ui/CarouselSongController.java
+++ b/backend/src/main/java/shook/shook/song/ui/CarouselSongController.java
@@ -1,0 +1,29 @@
+package shook.shook.song.ui;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import shook.shook.song.application.SongService;
+import shook.shook.song.application.dto.RecentSongCarouselResponse;
+import shook.shook.song.ui.openapi.CarouselSongApi;
+
+@RequiredArgsConstructor
+@RequestMapping("/songs/recent")
+@RestController
+public class CarouselSongController implements CarouselSongApi {
+
+    private final SongService songService;
+
+    @GetMapping
+    public ResponseEntity<List<RecentSongCarouselResponse>> findRecentSongsForCarousel(
+        @RequestParam(name = "size", defaultValue = "5", required = false) final Integer size
+    ) {
+        final List<RecentSongCarouselResponse> responses = songService.findRecentRegisteredSongsForCarousel(size);
+
+        return ResponseEntity.ok(responses);
+    }
+}

--- a/backend/src/main/java/shook/shook/song/ui/openapi/CarouselSongApi.java
+++ b/backend/src/main/java/shook/shook/song/ui/openapi/CarouselSongApi.java
@@ -1,0 +1,33 @@
+package shook.shook.song.ui.openapi;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import shook.shook.song.application.dto.RecentSongCarouselResponse;
+
+@Tag(name = "Carousel Songs", description = "메인페이지 캐러셀 조회 API")
+public interface CarouselSongApi {
+
+    @Operation(
+        summary = "캐러셀에 들어갈 노래 반환",
+        description = "캐러셀에 들어갈 노래 5개를 등록 최신 순 리스트로 반환한다."
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "최근에 등록된 노래 리스트 조회 성공"
+    )
+    @Parameter(
+        name = "size",
+        description = "조회할 개수",
+        example = "4"
+    )
+    @GetMapping
+    ResponseEntity<List<RecentSongCarouselResponse>> findRecentSongsForCarousel(
+        @RequestParam(name = "size", defaultValue = "5", required = false) final Integer size
+    );
+}

--- a/backend/src/test/java/shook/shook/song/application/SongServiceTest.java
+++ b/backend/src/test/java/shook/shook/song/application/SongServiceTest.java
@@ -16,6 +16,7 @@ import shook.shook.auth.ui.argumentresolver.MemberInfo;
 import shook.shook.member.domain.Member;
 import shook.shook.member.domain.repository.MemberRepository;
 import shook.shook.song.application.dto.KillingPartRegisterRequest;
+import shook.shook.song.application.dto.RecentSongCarouselResponse;
 import shook.shook.song.application.dto.SongResponse;
 import shook.shook.song.application.dto.SongSwipeResponse;
 import shook.shook.song.application.dto.SongWithKillingPartsRegisterRequest;
@@ -424,5 +425,29 @@ class SongServiceTest extends UsingJpaTest {
                     .containsExactly(2L, 1L, 3L, 5L, 4L)
             );
         }
+    }
+
+    @DisplayName("최근에 등록된 순으로 노래 5개를 조회한다.")
+    @Test
+    void findRecentRegisteredSongsForCarousel() {
+        // given
+        registerNewSong("노래1");
+        registerNewSong("노래2");
+        registerNewSong("노래3");
+        registerNewSong("노래4");
+        registerNewSong("노래5");
+        registerNewSong("노래6");
+        registerNewSong("노래7");
+
+        saveAndClearEntityManager();
+
+        // when
+        final List<RecentSongCarouselResponse> songs = songService.findRecentRegisteredSongsForCarousel(5);
+
+        // then
+        assertThat(songs.stream()
+            .map(RecentSongCarouselResponse::getId)
+            .toList())
+            .containsExactly(7L, 6L, 5L, 4L, 3L);
     }
 }

--- a/backend/src/test/java/shook/shook/song/domain/repository/SongRepositoryTest.java
+++ b/backend/src/test/java/shook/shook/song/domain/repository/SongRepositoryTest.java
@@ -359,4 +359,21 @@ class SongRepositoryTest extends UsingJpaTest {
             .isEqualTo(
                 List.of(fourthSong, fifthSong, firstSong, secondSong, thirdSong));
     }
+
+    @DisplayName("노래 최신순으로 정렬하여 상위 노래를 조회한다.")
+    @Test
+    void findSongsOrderById() {
+        // given
+        final Song song1 = songRepository.save(createNewSongWithKillingParts());
+        final Song song2 = songRepository.save(createNewSongWithKillingParts());
+        final Song song3 = songRepository.save(createNewSongWithKillingParts());
+        final Song song4 = songRepository.save(createNewSongWithKillingParts());
+        final Song song5 = songRepository.save(createNewSongWithKillingParts());
+
+        // when
+        final List<Song> songs = songRepository.findSongsOrderById(PageRequest.of(0, 4));
+
+        // then
+        assertThat(songs).containsExactly(song5, song4, song3, song2);
+    }
 }

--- a/backend/src/test/java/shook/shook/song/ui/CarouselSongControllerTest.java
+++ b/backend/src/test/java/shook/shook/song/ui/CarouselSongControllerTest.java
@@ -1,0 +1,102 @@
+package shook.shook.song.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.jdbc.Sql;
+import shook.shook.part.domain.PartLength;
+import shook.shook.song.application.dto.RecentSongCarouselResponse;
+import shook.shook.song.domain.Genre;
+import shook.shook.song.domain.KillingParts;
+import shook.shook.song.domain.Song;
+import shook.shook.song.domain.killingpart.KillingPart;
+import shook.shook.song.domain.repository.SongRepository;
+
+@Sql("classpath:/killingpart/initialize_killing_part_song.sql")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class CarouselSongControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private SongRepository songRepository;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("캐러셀에 보여질 노래들을 조회하면 200 상태코드와 id 높은 순 노래 데이터가 반환된다.")
+    @Test
+    void findRecentSongsForCarousel() {
+        // given
+        songRepository.findById(3L).get();
+        songRepository.findById(4L).get();
+        songRepository.save(createNewSongWithKillingParts());
+        songRepository.save(createNewSongWithKillingParts());
+
+        // when
+        final List<RecentSongCarouselResponse> response = RestAssured.given().log().all()
+            .param("size", 4)
+            .when().log().all()
+            .get("/songs/recent")
+            .then().log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract()
+            .body().jsonPath().getList(".", RecentSongCarouselResponse.class);
+
+        // then
+        assertThat(response).hasSize(4);
+        assertThat(response.stream()
+            .map(RecentSongCarouselResponse::getId)
+            .toList())
+            .containsExactly(6L, 5L, 4L, 3L);
+    }
+
+    @DisplayName("캐러셀에 보여질 노래들을 조회할 때, size 파라미터가 전달되지 않으면 기본값인 5개가 조회된다.")
+    @Test
+    void findRecentSongsForCarousel_noParam() {
+        // given
+        songRepository.findById(3L).get();
+        songRepository.findById(4L).get();
+        songRepository.save(createNewSongWithKillingParts());
+        songRepository.save(createNewSongWithKillingParts());
+        songRepository.save(createNewSongWithKillingParts());
+
+        // when
+        final List<RecentSongCarouselResponse> response = RestAssured.given().log().all()
+            .when().log().all()
+            .get("/songs/recent")
+            .then().log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract()
+            .body().jsonPath().getList(".", RecentSongCarouselResponse.class);
+
+        // then
+        assertThat(response).hasSize(5);
+        assertThat(response.stream()
+            .map(RecentSongCarouselResponse::getId)
+            .toList())
+            .containsExactly(7L, 6L, 5L, 4L, 3L);
+    }
+
+    private Song createNewSongWithKillingParts() {
+        final KillingPart firstKillingPart = KillingPart.forSave(10, PartLength.SHORT);
+        final KillingPart secondKillingPart = KillingPart.forSave(15, PartLength.SHORT);
+        final KillingPart thirdKillingPart = KillingPart.forSave(20, PartLength.SHORT);
+
+        return new Song(
+            "제목", "비디오ID는 11글자", "이미지URL", "가수", 5, Genre.from("댄스"),
+            new KillingParts(List.of(firstKillingPart, secondKillingPart, thirdKillingPart)));
+    }
+}


### PR DESCRIPTION
## 📝작업 내용

캐러셀용 최신 노래 조회 API 구현
- [x] 파라미터로 조회할 개수를 전달받을 수 있습니다. `GET /songs/recent?size=4`
- [x] 파라미터를 담지 않으면 기본값인 5개가 전달됩니다. `GET /songs/recent`  -> 5개 조회

## #️⃣연관된 이슈
close #515


