### PR TITLE
Hotfix#505 sm 이하 넓이에서는 컨테이너가 flex-start가 되도록 변경

### DIFF
--- a/frontend/src/features/songs/components/SongDetailItem.tsx
+++ b/frontend/src/features/songs/components/SongDetailItem.tsx
@@ -88,6 +88,10 @@ const Container = styled.div`
   height: 100vh;
   padding-top: ${({ theme: { headerHeight } }) => headerHeight.desktop};
 
+  @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
+    justify-content: flex-start;
+  }
+
   @media (max-width: ${({ theme }) => theme.breakPoints.xs}) {
     padding-top: ${({ theme: { headerHeight } }) => headerHeight.mobile};
   }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

모바일에서는 중앙 정렬시 잘 안보여서 sm 사이즈 이하로는 flex-start로 설정

## 💬리뷰 참고사항

> 원활한 리뷰를 위해 전달하고 싶은 맥락(특정 파일, 디렉터리 등등)  
> 리뷰어가 특별히 봐주었으면 하는 부분

참고사항

## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성

(close) #이슈번호


