### PR TITLE
Refactor/#551 SongDetailListPage의 스와이프 추가 fetch 옵져버 로직에 callbackRef를 적용하여 로직 흐름을 개선한다.

### DIFF
--- a/frontend/src/features/songs/hooks/useExtraSongDetail.ts
+++ b/frontend/src/features/songs/hooks/useExtraSongDetail.ts
@@ -22,29 +22,29 @@ const useExtraSongDetail = () => {
   const nextObserverRef = useRef<IntersectionObserver | null>(null);
 
   const getExtraPrevSongDetailsOnObserve: React.RefCallback<HTMLDivElement> = useCallback((dom) => {
-    if (dom === null) {
-      prevObserverRef.current?.disconnect();
+    if (dom !== null) {
+      prevObserverRef.current = createObserver(() =>
+        fetchExtraPrevSongDetails(getFirstSongId(dom), genreParams as Genre)
+      );
+
+      prevObserverRef.current.observe(dom);
       return;
     }
 
-    prevObserverRef.current = createObserver(() =>
-      fetchExtraPrevSongDetails(getFirstSongId(dom), genreParams as Genre)
-    );
-
-    prevObserverRef.current.observe(dom);
+    prevObserverRef.current?.disconnect();
   }, []);
 
   const getExtraNextSongDetailsOnObserve: React.RefCallback<HTMLDivElement> = useCallback((dom) => {
-    if (dom === null) {
-      nextObserverRef.current?.disconnect();
+    if (dom !== null) {
+      nextObserverRef.current = createObserver(() =>
+        fetchExtraNextSongDetails(getLastSongId(dom), genreParams as Genre)
+      );
+
+      nextObserverRef.current.observe(dom);
       return;
     }
 
-    nextObserverRef.current = createObserver(() =>
-      fetchExtraNextSongDetails(getLastSongId(dom), genreParams as Genre)
-    );
-
-    nextObserverRef.current.observe(dom);
+    nextObserverRef.current?.disconnect();
   }, []);
 
   const getFirstSongId = (dom: HTMLDivElement) => {

--- a/frontend/src/features/songs/hooks/useExtraSongDetail.ts
+++ b/frontend/src/features/songs/hooks/useExtraSongDetail.ts
@@ -1,0 +1,70 @@
+import { useCallback, useRef } from 'react';
+import useExtraFetch from '@/shared/hooks/useExtraFetch';
+import useValidParams from '@/shared/hooks/useValidParams';
+import createObserver from '@/shared/utils/createObserver';
+import { getExtraNextSongDetails, getExtraPrevSongDetails } from '../remotes/songs';
+import type { Genre } from '../types/Song.type';
+
+const useExtraSongDetail = () => {
+  const { genre: genreParams } = useValidParams();
+
+  const { data: extraPrevSongDetails, fetchData: fetchExtraPrevSongDetails } = useExtraFetch(
+    getExtraPrevSongDetails,
+    'prev'
+  );
+
+  const { data: extraNextSongDetails, fetchData: fetchExtraNextSongDetails } = useExtraFetch(
+    getExtraNextSongDetails,
+    'next'
+  );
+
+  const prevObserverRef = useRef<IntersectionObserver | null>(null);
+  const nextObserverRef = useRef<IntersectionObserver | null>(null);
+
+  const getExtraPrevSongDetailsOnObserve: React.RefCallback<HTMLDivElement> = useCallback((dom) => {
+    if (dom === null) {
+      prevObserverRef.current?.disconnect();
+      return;
+    }
+
+    prevObserverRef.current = createObserver(() =>
+      fetchExtraPrevSongDetails(getFirstSongId(dom), genreParams as Genre)
+    );
+
+    prevObserverRef.current.observe(dom);
+  }, []);
+
+  const getExtraNextSongDetailsOnObserve: React.RefCallback<HTMLDivElement> = useCallback((dom) => {
+    if (dom === null) {
+      nextObserverRef.current?.disconnect();
+      return;
+    }
+
+    nextObserverRef.current = createObserver(() =>
+      fetchExtraNextSongDetails(getLastSongId(dom), genreParams as Genre)
+    );
+
+    nextObserverRef.current.observe(dom);
+  }, []);
+
+  const getFirstSongId = (dom: HTMLDivElement) => {
+    const firstSongId = dom.nextElementSibling?.getAttribute('data-song-id') as string;
+
+    return Number(firstSongId);
+  };
+
+  const getLastSongId = (dom: HTMLDivElement) => {
+    const lastSongId = dom.previousElementSibling?.getAttribute('data-song-id') as string;
+
+    return Number(lastSongId);
+  };
+
+  return {
+    extraPrevSongDetails,
+    extraNextSongDetails,
+    getExtraPrevSongDetailsOnObserve,
+    getExtraNextSongDetailsOnObserve,
+  };
+};
+
+export default useExtraSongDetail;

--- a/frontend/src/features/songs/hooks/useSongDetailEntries.ts
+++ b/frontend/src/features/songs/hooks/useSongDetailEntries.ts
@@ -1,0 +1,22 @@
+import { useLayoutEffect, useRef } from 'react';
+import useFetch from '@/shared/hooks/useFetch';
+import useValidParams from '@/shared/hooks/useValidParams';
+import { getSongDetailEntries } from '../remotes/songs';
+import type { Genre } from '../types/Song.type';
+
+const useSongDetailEntries = () => {
+  const { id: songIdParams, genre: genreParams } = useValidParams();
+  const currentSongDetailItemRef = useRef<HTMLDivElement>(null);
+
+  const { data: songDetailEntries } = useFetch(() =>
+    getSongDetailEntries(Number(songIdParams), genreParams as Genre)
+  );
+
+  useLayoutEffect(() => {
+    currentSongDetailItemRef.current?.scrollIntoView({ behavior: 'instant', block: 'start' });
+  }, [songDetailEntries]);
+
+  return { songDetailEntries, currentSongDetailItemRef };
+};
+
+export default useSongDetailEntries;

--- a/frontend/src/features/songs/hooks/useSongDetailEntries.ts
+++ b/frontend/src/features/songs/hooks/useSongDetailEntries.ts
@@ -12,9 +12,7 @@ const useSongDetailEntries = () => {
   );
 
   const scrollIntoCurrentSong: React.RefCallback<HTMLDivElement> = useCallback((dom) => {
-    if (dom === null) return;
-
-    dom.scrollIntoView({ behavior: 'instant', block: 'start' });
+    if (dom !== null) dom.scrollIntoView({ behavior: 'instant', block: 'start' });
   }, []);
 
   return { songDetailEntries, scrollIntoCurrentSong };

--- a/frontend/src/features/songs/hooks/useSongDetailEntries.ts
+++ b/frontend/src/features/songs/hooks/useSongDetailEntries.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import useFetch from '@/shared/hooks/useFetch';
 import useValidParams from '@/shared/hooks/useValidParams';
 import { getSongDetailEntries } from '../remotes/songs';
@@ -6,17 +6,18 @@ import type { Genre } from '../types/Song.type';
 
 const useSongDetailEntries = () => {
   const { id: songIdParams, genre: genreParams } = useValidParams();
-  const currentSongDetailItemRef = useRef<HTMLDivElement>(null);
 
   const { data: songDetailEntries } = useFetch(() =>
     getSongDetailEntries(Number(songIdParams), genreParams as Genre)
   );
 
-  useLayoutEffect(() => {
-    currentSongDetailItemRef.current?.scrollIntoView({ behavior: 'instant', block: 'start' });
-  }, [songDetailEntries]);
+  const scrollIntoCurrentSong: React.RefCallback<HTMLDivElement> = useCallback((dom) => {
+    if (dom === null) return;
 
-  return { songDetailEntries, currentSongDetailItemRef };
+    dom.scrollIntoView({ behavior: 'instant', block: 'start' });
+  }, []);
+
+  return { songDetailEntries, scrollIntoCurrentSong };
 };
 
 export default useSongDetailEntries;

--- a/frontend/src/mocks/handlers/songsHandlers.ts
+++ b/frontend/src/mocks/handlers/songsHandlers.ts
@@ -2,7 +2,6 @@ import { rest } from 'msw';
 import comments from '../fixtures/comments.json';
 import extraNextSongDetails from '../fixtures/extraNextSongDetails.json';
 import extraPrevSongDetails from '../fixtures/extraPrevSongDetails.json';
-import popularSongs from '../fixtures/popularSongs.json';
 import recentSongs from '../fixtures/recentSongs.json';
 import songEntries from '../fixtures/songEntries.json';
 import type { KillingPartPostRequest } from '@/shared/types/killingPart';
@@ -10,11 +9,6 @@ import type { KillingPartPostRequest } from '@/shared/types/killingPart';
 const { BASE_URL } = process.env;
 
 const songsHandlers = [
-  rest.get(`${BASE_URL}/songs/high-liked`, (req, res, ctx) => {
-    // const genre = req.url.searchParams.get('genre')
-    return res(ctx.status(200), ctx.json(popularSongs));
-  }),
-
   rest.get(`${BASE_URL}/songs/:songId/parts/:partId/comments`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(comments));
   }),
@@ -45,13 +39,24 @@ const songsHandlers = [
     return res(ctx.status(200), ctx.json(songEntries));
   }),
   rest.get(`${BASE_URL}/songs/high-liked/:songId/prev`, (req, res, ctx) => {
-    // const genre = req.url.searchParams.get('genre')
-    return res(ctx.status(200), ctx.json(extraPrevSongDetails));
+    // const genre = req.url.searchParams.get('genre');
+    const { songId } = req.params;
+
+    const targetIdx = extraPrevSongDetails.findIndex((song) => song.id === Number(songId));
+    const sliced = extraPrevSongDetails.slice(0, targetIdx);
+
+    return res(ctx.status(200), ctx.json(sliced));
   }),
 
   rest.get(`${BASE_URL}/songs/high-liked/:songId/next`, (req, res, ctx) => {
     // const genre = req.url.searchParams.get('genre')
-    return res(ctx.status(200), ctx.json(extraNextSongDetails));
+
+    const { songId } = req.params;
+
+    const targetIdx = extraNextSongDetails.findIndex((song) => song.id === Number(songId));
+    const sliced = extraNextSongDetails.slice(targetIdx);
+
+    return res(ctx.status(200), ctx.json(sliced));
   }),
 
   rest.get(`${BASE_URL}/songs/recent`, (req, res, ctx) => {

--- a/frontend/src/pages/SongDetailListPage.tsx
+++ b/frontend/src/pages/SongDetailListPage.tsx
@@ -12,7 +12,7 @@ const SongDetailListPage = () => {
   const { isOpen, closeModal } = useModal(true);
   const [onboarding, setOnboarding] = useLocalStorage<boolean>('onboarding', true);
 
-  const { songDetailEntries, currentSongDetailItemRef } = useSongDetailEntries();
+  const { songDetailEntries, scrollIntoCurrentSong } = useSongDetailEntries();
 
   const {
     extraPrevSongDetails,
@@ -60,7 +60,7 @@ const SongDetailListPage = () => {
           <SongDetailItem key={prevSongDetail.id} {...prevSongDetail} />
         ))}
 
-        <SongDetailItem ref={currentSongDetailItemRef} key={currentSong.id} {...currentSong} />
+        <SongDetailItem ref={scrollIntoCurrentSong} key={currentSong.id} {...currentSong} />
 
         {nextSongs.map((nextSongDetail) => (
           <SongDetailItem key={nextSongDetail.id} {...nextSongDetail} />


### PR DESCRIPTION
## 📝작업 내용

- effect를 제거하고 callbackRef를 적용하였습니다~!
- SongDetailListPage 내의 로직을 커스텀 훅으로 분리하였습니다.
  - useExtraSongDetail
  - useSongDetailEntries

## 💬리뷰 참고사항

파일이 추가되어 변경사항이 많아보입니다만, 사실 원래있던 로직 분리만 한거라 변경사항은 딱 1개입니다
**effect를 제거하고 내부 로직을 callbackRef 함수로 이동시켰어요!**
이 개선 사항은 제가 몇 번 설명했던 부분이라 변경사항 쉽게 파악 가능하실거에요!

- **page 단위에 있던 로직을 hook으로 분리한거라** 어디에 둘지 조금 **애매**하긴했는데, **songs/hooks 하위로 위치시켰습니다.**

## #️⃣연관된 이슈

close #551 


