### PR TITLE
Feat/#550 Confirm Modal 구현

### DIFF
--- a/frontend/practice.js
+++ b/frontend/practice.js
@@ -1,1 +1,0 @@
-const a = new Date(); //?

--- a/frontend/src/features/killingParts/components/RegisterPart.tsx
+++ b/frontend/src/features/killingParts/components/RegisterPart.tsx
@@ -75,7 +75,6 @@ const RegisterButton = styled.button`
 
   @media (min-width: ${({ theme }) => theme.breakPoints.md}) {
     padding: 11px 15px;
-
     font-size: 18px;
   }
 `;

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
@@ -1,31 +1,31 @@
 import styled from 'styled-components';
-import ConfirmProvider from './ConfirmModalProvider';
-import { useConfirm } from './hooks/useConfirm';
+import ConfirmModalProvider from './ConfirmModalProvider';
+import { useConfirmContext } from './hooks/useConfirmContext';
 import type { Meta, StoryObj } from '@storybook/react';
 
-const meta: Meta<typeof ConfirmProvider> = {
+const meta: Meta<typeof ConfirmModalProvider> = {
   title: 'shared/Confirm',
-  component: ConfirmProvider,
+  component: ConfirmModalProvider,
   decorators: [
     (Story) => (
-      <ConfirmProvider>
+      <ConfirmModalProvider>
         <Story />
-      </ConfirmProvider>
+      </ConfirmModalProvider>
     ),
   ],
 };
 
 export default meta;
 
-type Story = StoryObj<typeof ConfirmProvider>;
+type Story = StoryObj<typeof ConfirmModalProvider>;
 
 export const Example: Story = {
   render: () => {
     const Modal = () => {
-      const { confirm } = useConfirm();
+      const { confirmPopup } = useConfirmContext();
 
       const clickHiByeBtn = async () => {
-        const isConfirmed = await confirm({
+        const isConfirmed = await confirmPopup({
           title: '하이바이 모달',
           content: (
             <>
@@ -47,7 +47,7 @@ export const Example: Story = {
 
       // denial과 confirmation 기본값은 '닫기'와 '확인'입니다.
       const clickOpenCloseBtn = async () => {
-        const isConfirmed = await confirm({
+        const isConfirmed = await confirmPopup({
           title: '오쁜클로즈 모달',
           content: (
             <>

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
@@ -82,8 +82,8 @@ const Body = styled.div`
 `;
 
 const Button = styled.button`
+  padding: 4px 11px;
   color: white;
   border: 2px solid white;
-  padding: 4px 11px;
   border-radius: 4px;
 `;

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
-import ConfirmProvider, { useConfirm } from './ConfirmModalProvider';
+import ConfirmProvider from './ConfirmModalProvider';
+import { useConfirm } from './hooks/useConfirm';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof ConfirmProvider> = {
@@ -23,30 +24,50 @@ export const Example: Story = {
     const RegistrationModal = () => {
       const { confirm } = useConfirm();
 
-      const clickModalBtn = async () => {
+      const clickHiByeBtn = async () => {
         const isConfirmed = await confirm({
-          title: '제목',
+          title: '하이바이 모달',
           content: (
             <>
               <p>도밥은 정말 도밥입니까?</p>
               <p>코난은 정말 코난입니까?</p>
             </>
           ),
+          cancelName: '바이',
+          confirmName: '하이',
         });
 
-        console.log('isConfirmed', isConfirmed);
-
         if (isConfirmed) {
-          console.log('confirmed');
+          alert('confirmed');
           return;
         }
 
-        console.log('denied');
+        alert('denied');
+      };
+
+      const clickOpenCloseBtn = async () => {
+        const isConfirmed = await confirm({
+          title: '오쁜클로즈 모달',
+          content: (
+            <>
+              <p>코난은 정말 코난입니까?</p>
+              <p>도밥은 정말 도밥입니까?</p>
+            </>
+          ),
+        });
+
+        if (isConfirmed) {
+          alert('confirmed');
+          return;
+        }
+
+        alert('denied');
       };
 
       return (
         <Body>
-          <Button onClick={clickModalBtn}>모달 열기</Button>
+          <Button onClick={clickHiByeBtn}>하이바이 모달열기</Button>
+          <Button onClick={clickOpenCloseBtn}>닫기확인 모달열기</Button>
         </Body>
       );
     };

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
@@ -1,0 +1,67 @@
+import styled from 'styled-components';
+import ConfirmProvider, { useConfirm } from './ConfirmModalProvider';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof ConfirmProvider> = {
+  title: 'shared/Confirm',
+  component: ConfirmProvider,
+  decorators: [
+    (Story) => (
+      <ConfirmProvider>
+        <Story />
+      </ConfirmProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ConfirmProvider>;
+
+export const Example: Story = {
+  render: () => {
+    const RegistrationModal = () => {
+      const { confirm } = useConfirm();
+
+      const clickModalBtn = async () => {
+        const isConfirmed = await confirm({
+          title: '제목',
+          content: (
+            <>
+              <p>도밥은 정말 도밥입니까?</p>
+              <p>코난은 정말 코난입니까?</p>
+            </>
+          ),
+        });
+
+        console.log('isConfirmed', isConfirmed);
+
+        if (isConfirmed) {
+          console.log('confirmed');
+          return;
+        }
+
+        console.log('denied');
+      };
+
+      return (
+        <Body>
+          <Button onClick={clickModalBtn}>모달 열기</Button>
+        </Body>
+      );
+    };
+
+    return <RegistrationModal />;
+  },
+};
+
+const Body = styled.div`
+  height: 2400px;
+`;
+
+const Button = styled.button`
+  color: white;
+  border: 2px solid white;
+  padding: 4px 11px;
+  border-radius: 4px;
+`;

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof ConfirmProvider>;
 
 export const Example: Story = {
   render: () => {
-    const RegistrationModal = () => {
+    const Modal = () => {
       const { confirm } = useConfirm();
 
       const clickHiByeBtn = async () => {
@@ -33,8 +33,8 @@ export const Example: Story = {
               <p>코난은 정말 코난입니까?</p>
             </>
           ),
-          cancelName: '바이',
-          confirmName: '하이',
+          denial: '바이',
+          confirmation: '하이',
         });
 
         if (isConfirmed) {
@@ -45,6 +45,7 @@ export const Example: Story = {
         alert('denied');
       };
 
+      // denial과 confirmation 기본값은 '닫기'와 '확인'입니다.
       const clickOpenCloseBtn = async () => {
         const isConfirmed = await confirm({
           title: '오쁜클로즈 모달',
@@ -72,7 +73,7 @@ export const Example: Story = {
       );
     };
 
-    return <RegistrationModal />;
+    return <Modal />;
   },
 };
 

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -1,0 +1,56 @@
+import { createContext, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Flex } from 'shook-layout';
+import styled from 'styled-components';
+import type { ReactNode } from 'react';
+
+const ConfirmContext = createContext<null>(null);
+
+const Backdrop = styled.div``;
+const ContainerFlex = styled(Flex)``;
+const ButtonFlex = styled(Flex)``;
+const Title = styled.header``;
+const Content = styled.div``;
+const CancelButton = styled.button``;
+const ConfirmButton = styled.button``;
+
+interface ModalState {
+  title: string;
+  content: ReactNode;
+  cancelName: string;
+  confirmName: string;
+}
+
+const ConfirmProvider = (children: ReactNode) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [modalState, setModalState] = useState<ModalState>({
+    title: '',
+    content: '',
+    cancelName: '닫기',
+    confirmName: '확인',
+  });
+  const { title, content, cancelName, confirmName } = modalState;
+
+  return (
+    <ConfirmContext.Provider value={null}>
+      {children}
+      {isOpen &&
+        createPortal(
+          <>
+            <Backdrop />
+            <ContainerFlex>
+              <Title>{title}</Title>
+              <Content>{content}</Content>
+              <ButtonFlex>
+                <CancelButton>{cancelName}</CancelButton>
+                <ConfirmButton>{confirmName}</ConfirmButton>
+              </ButtonFlex>
+            </ContainerFlex>
+          </>,
+          document.body
+        )}
+    </ConfirmContext.Provider>
+  );
+};
+
+export default ConfirmProvider;

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -21,11 +21,17 @@ const ConfirmModal = ({
   onDeny,
   onConfirm,
 }: ConfirmModalProps) => {
+  const focusTitle: React.RefCallback<HTMLDivElement> = (dom) => {
+    dom && dom.focus();
+  };
+
   return createPortal(
     <>
       <Backdrop role="dialog" aria-modal="true" />
       <Container>
-        <Title>{title}</Title>
+        <Title ref={focusTitle} tabIndex={0}>
+          {title}
+        </Title>
         <Spacing direction="vertical" size={10} />
         <Content>{content}</Content>
         <Spacing direction="vertical" size={10} />

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -4,7 +4,9 @@ import { Flex } from 'shook-layout';
 import styled from 'styled-components';
 import type { ReactNode } from 'react';
 
-const ConfirmContext = createContext<null>(null);
+const ConfirmContext = createContext<null | {
+  getConfirmation: (modalState: ModalState) => Promise<boolean>;
+}>(null);
 
 const Backdrop = styled.div``;
 const ContainerFlex = styled(Flex)``;
@@ -17,12 +19,24 @@ const ConfirmButton = styled.button``;
 interface ModalState {
   title: string;
   content: ReactNode;
-  cancelName: string;
-  confirmName: string;
+  cancelName?: string;
+  confirmName?: string;
 }
+
+type Resolver<T> = (value: T) => void;
+
+const createPromise = <T,>() => {
+  let resolver: Resolver<T> | null = null;
+  const promise = new Promise<T>((resolve) => {
+    resolver = resolve;
+  });
+
+  return { promise, resolver };
+};
 
 const ConfirmProvider = (children: ReactNode) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [resolve, setResolve] = useState<((value: boolean) => void) | null>(null);
   const [modalState, setModalState] = useState<ModalState>({
     title: '',
     content: '',
@@ -31,8 +45,33 @@ const ConfirmProvider = (children: ReactNode) => {
   });
   const { title, content, cancelName, confirmName } = modalState;
 
+  const getConfirmation = ({
+    cancelName = '닫기',
+    confirmName = '확인',
+    ...restState
+  }: ModalState): Promise<boolean> => {
+    const { promise, resolver } = createPromise<boolean>();
+    setResolve(resolver);
+    setModalState({
+      cancelName,
+      confirmName,
+      ...restState,
+    });
+    setIsOpen(true);
+
+    return promise;
+  };
+
+  const onClick = (status: boolean) => {
+    setIsOpen(false);
+
+    if (resolve) {
+      resolve(status);
+    }
+  };
+
   return (
-    <ConfirmContext.Provider value={null}>
+    <ConfirmContext.Provider value={{ getConfirmation }}>
       {children}
       {isOpen &&
         createPortal(
@@ -42,8 +81,8 @@ const ConfirmProvider = (children: ReactNode) => {
               <Title>{title}</Title>
               <Content>{content}</Content>
               <ButtonFlex>
-                <CancelButton>{cancelName}</CancelButton>
-                <ConfirmButton>{confirmName}</ConfirmButton>
+                <CancelButton onClick={() => onClick(false)}>{cancelName}</CancelButton>
+                <ConfirmButton onClick={() => onClick(true)}>{confirmName}</ConfirmButton>
               </ButtonFlex>
             </ContainerFlex>
           </>,

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from 'react-dom';
 import { Flex } from 'shook-layout';
 import styled, { css } from 'styled-components';
 import Spacing from '../Spacing';
@@ -20,7 +21,7 @@ const ConfirmModal = ({
   onCancel,
   onConfirm,
 }: ConfirmModalProps) => {
-  return (
+  return createPortal(
     <>
       <Backdrop role="dialog" aria-modal="true" />
       <Container>
@@ -33,7 +34,8 @@ const ConfirmModal = ({
           <ConfirmButton onClick={onConfirm}>{confirmName}</ConfirmButton>
         </ButtonFlex>
       </Container>
-    </>
+    </>,
+    document.body
   );
 };
 

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -1,4 +1,3 @@
-import { createPortal } from 'react-dom';
 import { Flex } from 'shook-layout';
 import styled, { css } from 'styled-components';
 import Spacing from '../Spacing';
@@ -25,7 +24,7 @@ const ConfirmModal = ({
     dom && dom.focus();
   };
 
-  return createPortal(
+  return (
     <>
       <Backdrop role="dialog" aria-modal="true" />
       <Container>
@@ -44,8 +43,7 @@ const ConfirmModal = ({
           </ConfirmButton>
         </ButtonFlex>
       </Container>
-    </>,
-    document.body
+    </>
   );
 };
 

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -74,9 +74,9 @@ const Container = styled.section`
   margin: 0 auto;
   padding: 24px;
 
-  color: #ffffff;
+  color: ${({ theme: color }) => color.white};
 
-  background-color: #17171c;
+  background-color: ${({ theme: color }) => color.black300};
   border: none;
   border-radius: 16px;
 `;

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -74,9 +74,9 @@ const Container = styled.section`
   margin: 0 auto;
   padding: 24px;
 
-  color: ${({ theme: color }) => color.white};
+  color: ${({ theme: { color } }) => color.white};
 
-  background-color: ${({ theme: color }) => color.black300};
+  background-color: ${({ theme: { color } }) => color.black300};
   border: none;
   border-radius: 16px;
 `;

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -30,8 +30,12 @@ const ConfirmModal = ({
         <Content>{content}</Content>
         <Spacing direction="vertical" size={10} />
         <ButtonFlex $gap={16}>
-          <CancelButton onClick={onDeny}>{denial}</CancelButton>
-          <ConfirmButton onClick={onConfirm}>{confirmation}</ConfirmButton>
+          <CancelButton type="button" onClick={onDeny}>
+            {denial}
+          </CancelButton>
+          <ConfirmButton type="button" onClick={onConfirm}>
+            {confirmation}
+          </ConfirmButton>
         </ButtonFlex>
       </Container>
     </>,

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -30,9 +30,9 @@ const ConfirmModal = ({
         <Content>{content}</Content>
         <Spacing direction="vertical" size={10} />
         <ButtonFlex $gap={16}>
-          <CancelButton type="button" onClick={onDeny}>
+          <DenialButton type="button" onClick={onDeny}>
             {denial}
-          </CancelButton>
+          </DenialButton>
           <ConfirmButton type="button" onClick={onConfirm}>
             {confirmation}
           </ConfirmButton>
@@ -99,7 +99,7 @@ const buttonStyle = css`
   border-radius: 10px;
 `;
 
-const CancelButton = styled.button`
+const DenialButton = styled.button`
   background-color: ${({ theme: { color } }) => color.secondary};
   ${buttonStyle}
 `;

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -72,20 +72,25 @@ const Container = styled.section`
   border: none;
   border-radius: 16px;
 `;
+
 const ButtonFlex = styled(Flex)`
   width: 100%;
 `;
+
 const Title = styled.header`
-  text-align: left;
   font-size: 18px;
+  text-align: left;
 `;
+
 const Content = styled.div``;
 
 const buttonStyle = css`
   flex: 1;
-  height: 36px;
-  color: ${({ theme: { color } }) => color.white};
+
   width: 100%;
+  height: 36px;
+
+  color: ${({ theme: { color } }) => color.white};
 
   border-radius: 10px;
 `;
@@ -94,6 +99,7 @@ const CancelButton = styled.button`
   background-color: ${({ theme: { color } }) => color.secondary};
   ${buttonStyle}
 `;
+
 const ConfirmButton = styled.button`
   background-color: ${({ theme: { color } }) => color.primary};
   ${buttonStyle}

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -7,18 +7,18 @@ import type { ReactNode } from 'react';
 interface ConfirmModalProps {
   title: string;
   content: ReactNode;
-  cancelName: string;
-  confirmName: string;
-  onCancel: () => void;
+  denial: string;
+  confirmation: string;
+  onDeny: () => void;
   onConfirm: () => void;
 }
 
 const ConfirmModal = ({
   title,
   content,
-  cancelName,
-  confirmName,
-  onCancel,
+  denial,
+  confirmation,
+  onDeny,
   onConfirm,
 }: ConfirmModalProps) => {
   return createPortal(
@@ -30,8 +30,8 @@ const ConfirmModal = ({
         <Content>{content}</Content>
         <Spacing direction="vertical" size={10} />
         <ButtonFlex $gap={16}>
-          <CancelButton onClick={onCancel}>{cancelName}</CancelButton>
-          <ConfirmButton onClick={onConfirm}>{confirmName}</ConfirmButton>
+          <CancelButton onClick={onDeny}>{denial}</CancelButton>
+          <ConfirmButton onClick={onConfirm}>{confirmation}</ConfirmButton>
         </ButtonFlex>
       </Container>
     </>,

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { Flex } from 'shook-layout';
 import styled, { css } from 'styled-components';
 import Spacing from '../Spacing';
@@ -11,7 +10,6 @@ interface ConfirmModalProps {
   confirmName: string;
   onCancel: () => void;
   onConfirm: () => void;
-  onKeyDown: (event: KeyboardEvent) => void;
 }
 
 const ConfirmModal = ({
@@ -21,18 +19,7 @@ const ConfirmModal = ({
   confirmName,
   onCancel,
   onConfirm,
-  onKeyDown,
 }: ConfirmModalProps) => {
-  useEffect(() => {
-    document.addEventListener('keydown', onKeyDown);
-    document.body.style.overflow = 'hidden';
-
-    return () => {
-      document.removeEventListener('keydown', onKeyDown);
-      document.body.style.overflow = 'auto';
-    };
-  }, []);
-
   return (
     <>
       <Backdrop role="dialog" aria-modal="true" />

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModalProvider.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModalProvider.tsx
@@ -1,0 +1,111 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { createContext, useCallback, useContext, useState } from 'react';
+import { createPortal } from 'react-dom';
+import ConfirmModal from './ConfirmModal';
+import type { ReactNode } from 'react';
+
+const ConfirmContext = createContext<null | {
+  confirm: (modalState: ModalState) => Promise<boolean>;
+}>(null);
+
+interface ModalState {
+  title: string;
+  content: ReactNode;
+  cancelName?: string;
+  confirmName?: string;
+}
+
+const ConfirmProvider = ({ children }: { children: ReactNode }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [resolver, setResolver] = useState<{
+    resolve: (value: boolean | PromiseLike<boolean>) => void;
+  } | null>(null);
+  const [modalState, setModalState] = useState<ModalState>({
+    title: '',
+    content: '',
+    cancelName: '닫기',
+    confirmName: '확인',
+  });
+  const { title, content, cancelName, confirmName } = modalState;
+
+  const confirm = async (modal: ModalState) => {
+    openModal();
+    setModalState(modal);
+
+    const promise = await new Promise<boolean>((resolve) => {
+      setResolver({ resolve });
+    });
+
+    return promise;
+  };
+
+  const closeModal = () => {
+    setIsOpen(false);
+  };
+
+  const openModal = () => {
+    setIsOpen(true);
+  };
+
+  const resolveConfirmation = (status: boolean) => {
+    if (!resolver) return;
+
+    resolver.resolve(status);
+  };
+
+  const onCancel = useCallback(() => {
+    resolveConfirmation(false);
+    closeModal();
+  }, []);
+
+  const onConfirm = useCallback(() => {
+    resolveConfirmation(true);
+    closeModal();
+  }, []);
+
+  const onKeyDown = useCallback((event: KeyboardEvent) => {
+    const { key } = event;
+    if (key === 'Enter') {
+      event.preventDefault();
+      resolveConfirmation(false);
+      closeModal();
+      return;
+    }
+
+    if (key === 'Escape') {
+      resolveConfirmation(false);
+      closeModal();
+      return;
+    }
+  }, []);
+
+  return (
+    <ConfirmContext.Provider value={{ confirm }}>
+      {children}
+      {isOpen &&
+        createPortal(
+          <ConfirmModal
+            title={title}
+            content={content}
+            cancelName={cancelName ?? '닫기'}
+            confirmName={confirmName ?? '확인'}
+            onCancel={onCancel}
+            onConfirm={onConfirm}
+            onKeyDown={onKeyDown}
+          />,
+          document.body
+        )}
+    </ConfirmContext.Provider>
+  );
+};
+
+export default ConfirmProvider;
+
+export const useConfirm = () => {
+  const contextValue = useContext(ConfirmContext);
+  if (!contextValue) {
+    throw new Error('ConfirmContext Provider 내부에서 사용 가능합니다.');
+  }
+
+  return contextValue;
+};

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModalProvider.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModalProvider.tsx
@@ -18,7 +18,7 @@ interface ModalContents {
 const ConfirmProvider = ({ children }: { children: ReactNode }) => {
   const [isOpen, setIsOpen] = useState(false);
   const resolverRef = useRef<{
-    resolve: (value: boolean | PromiseLike<boolean>) => void;
+    resolve: (value: boolean) => void;
   } | null>(null);
   const [modalContents, setModalContents] = useState<ModalContents>({
     title: '',

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModalProvider.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModalProvider.tsx
@@ -88,7 +88,7 @@ const ConfirmProvider = ({ children }: { children: ReactNode }) => {
       document.removeEventListener('keydown', onKeyDown);
       document.body.style.overflow = 'auto';
     };
-  }, []);
+  }, [isOpen]);
 
   return (
     <ConfirmContext.Provider value={{ confirm }}>

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModalProvider.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModalProvider.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { createContext, useCallback, useContext, useState } from 'react';
+import { createContext, useCallback, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import ConfirmModal from './ConfirmModal';
 import type { ReactNode } from 'react';
 
-const ConfirmContext = createContext<null | {
+export const ConfirmContext = createContext<null | {
   confirm: (modalState: ModalState) => Promise<boolean>;
 }>(null);
 
@@ -69,14 +69,24 @@ const ConfirmProvider = ({ children }: { children: ReactNode }) => {
       event.preventDefault();
       resolveConfirmation(false);
       closeModal();
-      return;
     }
 
     if (key === 'Escape') {
       resolveConfirmation(false);
       closeModal();
-      return;
     }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener('keydown', onKeyDown);
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = 'auto';
+    };
   }, []);
 
   return (
@@ -91,7 +101,6 @@ const ConfirmProvider = ({ children }: { children: ReactNode }) => {
             confirmName={confirmName ?? '확인'}
             onCancel={onCancel}
             onConfirm={onConfirm}
-            onKeyDown={onKeyDown}
           />,
           document.body
         )}
@@ -100,12 +109,3 @@ const ConfirmProvider = ({ children }: { children: ReactNode }) => {
 };
 
 export default ConfirmProvider;
-
-export const useConfirm = () => {
-  const contextValue = useContext(ConfirmContext);
-  if (!contextValue) {
-    throw new Error('ConfirmContext Provider 내부에서 사용 가능합니다.');
-  }
-
-  return contextValue;
-};

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModalProvider.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModalProvider.tsx
@@ -5,14 +5,14 @@ import ConfirmModal from './ConfirmModal';
 import type { ReactNode } from 'react';
 
 export const ConfirmContext = createContext<null | {
-  confirm: (modalState: ModalState) => Promise<boolean>;
+  confirm: (modalState: ModalContents) => Promise<boolean>;
 }>(null);
 
-interface ModalState {
+interface ModalContents {
   title: string;
   content: ReactNode;
-  cancelName?: string;
-  confirmName?: string;
+  denial?: string;
+  confirmation?: string;
 }
 
 const ConfirmProvider = ({ children }: { children: ReactNode }) => {
@@ -20,17 +20,18 @@ const ConfirmProvider = ({ children }: { children: ReactNode }) => {
   const resolverRef = useRef<{
     resolve: (value: boolean | PromiseLike<boolean>) => void;
   } | null>(null);
-  const [modalState, setModalState] = useState<ModalState>({
+  const [modalContents, setModalContents] = useState<ModalContents>({
     title: '',
     content: '',
-    cancelName: '닫기',
-    confirmName: '확인',
+    denial: '닫기',
+    confirmation: '확인',
   });
-  const { title, content, cancelName, confirmName } = modalState;
+  const { title, content, denial, confirmation } = modalContents;
 
-  const confirm = (modal: ModalState) => {
+  // ContextAPI를 통해 confirm 함수만 제공합니다.
+  const confirm = (contents: ModalContents) => {
     openModal();
-    setModalState(modal);
+    setModalContents(contents);
 
     const promise = new Promise<boolean>((resolve) => {
       resolverRef.current = { resolve };
@@ -53,7 +54,7 @@ const ConfirmProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
-  const onCancel = useCallback(() => {
+  const onDeny = useCallback(() => {
     resolveConfirmation(false);
     closeModal();
   }, []);
@@ -97,9 +98,9 @@ const ConfirmProvider = ({ children }: { children: ReactNode }) => {
           <ConfirmModal
             title={title}
             content={content}
-            cancelName={cancelName ?? '닫기'}
-            confirmName={confirmName ?? '확인'}
-            onCancel={onCancel}
+            denial={denial ?? '닫기'}
+            confirmation={confirmation ?? '확인'}
+            onDeny={onDeny}
             onConfirm={onConfirm}
           />,
           document.body

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModalProvider.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModalProvider.tsx
@@ -64,14 +64,7 @@ const ConfirmProvider = ({ children }: { children: ReactNode }) => {
     closeModal();
   }, []);
 
-  const onKeyDown = useCallback((event: KeyboardEvent) => {
-    const { key } = event;
-    if (key === 'Enter') {
-      event.preventDefault();
-      resolveConfirmation(false);
-      closeModal();
-    }
-
+  const onKeyDown = useCallback(({ key }: KeyboardEvent) => {
     if (key === 'Escape') {
       resolveConfirmation(false);
       closeModal();

--- a/frontend/src/shared/components/ConfirmModal/ConfirmModalProvider.tsx
+++ b/frontend/src/shared/components/ConfirmModal/ConfirmModalProvider.tsx
@@ -5,7 +5,7 @@ import ConfirmModal from './ConfirmModal';
 import type { ReactNode } from 'react';
 
 export const ConfirmContext = createContext<null | {
-  confirm: (modalState: ModalContents) => Promise<boolean>;
+  confirmPopup: (modalState: ModalContents) => Promise<boolean>;
 }>(null);
 
 interface ModalContents {
@@ -15,7 +15,7 @@ interface ModalContents {
   confirmation?: string;
 }
 
-const ConfirmProvider = ({ children }: { children: ReactNode }) => {
+const ConfirmModalProvider = ({ children }: { children: ReactNode }) => {
   const [isOpen, setIsOpen] = useState(false);
   const resolverRef = useRef<{
     resolve: (value: boolean) => void;
@@ -29,7 +29,7 @@ const ConfirmProvider = ({ children }: { children: ReactNode }) => {
   const { title, content, denial, confirmation } = modalContents;
 
   // ContextAPI를 통해 confirm 함수만 제공합니다.
-  const confirm = (contents: ModalContents) => {
+  const confirmPopup = (contents: ModalContents) => {
     openModal();
     setModalContents(contents);
 
@@ -84,7 +84,7 @@ const ConfirmProvider = ({ children }: { children: ReactNode }) => {
   }, [isOpen]);
 
   return (
-    <ConfirmContext.Provider value={{ confirm }}>
+    <ConfirmContext.Provider value={{ confirmPopup }}>
       {children}
       {isOpen &&
         createPortal(
@@ -102,4 +102,4 @@ const ConfirmProvider = ({ children }: { children: ReactNode }) => {
   );
 };
 
-export default ConfirmProvider;
+export default ConfirmModalProvider;

--- a/frontend/src/shared/components/ConfirmModal/hooks/useConfirm.ts
+++ b/frontend/src/shared/components/ConfirmModal/hooks/useConfirm.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { ConfirmContext } from '../ConfirmModalProvider';
+
+export const useConfirm = () => {
+  const contextValue = useContext(ConfirmContext);
+  if (!contextValue) {
+    throw new Error('ConfirmContext Provider 내부에서 사용 가능합니다.');
+  }
+
+  return contextValue;
+};

--- a/frontend/src/shared/components/ConfirmModal/hooks/useConfirmContext.ts
+++ b/frontend/src/shared/components/ConfirmModal/hooks/useConfirmContext.ts
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import { ConfirmContext } from '../ConfirmModalProvider';
 
-export const useConfirm = () => {
+export const useConfirmContext = () => {
   const contextValue = useContext(ConfirmContext);
   if (!contextValue) {
     throw new Error('ConfirmContext Provider 내부에서 사용 가능합니다.');


### PR DESCRIPTION
## 📝작업 내용
전역에서 사용할 Confirm Modal을 구현하였습니다. 
- 스타일은 기존 모달과 같습니다.
- Confirm Modal 은 여러개를 띄울 일이 없기 때문에 전역에 두었습니다.
- `useConfirm` 을 사용하여 confirm 함수를 사용하시면 됩니다.
## 💬리뷰 참고사항
1. `useConfirm` 사용법
- 인자
  - `title`, `content`, `denial`, `confirmation` 을 객체로 인자를 받습니다.
  - `content` 타입은 ReactNode이며 나머지는 string만 받습니다.
  - `denial`, `confirmation` 은 버튼의 이름을 뜻합니다. 기본값은 닫기와 확인입니다.
- 반환값
  - `Promise<boolean>`을 반환합니다.
  - useConfirm 사용처에서 확인/닫기 시에 어떤 일을 할 지 작성할 수 있습니다.

2. 스토리북을 이용해주세요.
**기존 코드에서 confirm 성격의 모달을 사용하는 곳에 아직 대체하지 않았습니다.** 해당 PR이 approve 받으면 변경 적용하는 작업을 별도의 PR로 하겠습니다. 이유는 리뷰 중에 해당 구현이 변경될 수 있기 때문입니다.

## #️⃣연관된 이슈
close #550 


