### PR TITLE
Feat/#558 스와이프, 댓글 기능에 React-Query 적용

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
+        "@tanstack/react-query": "^5.14.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.1",
@@ -29,6 +30,7 @@
         "@storybook/react": "^7.0.27",
         "@storybook/react-webpack5": "^7.0.27",
         "@storybook/testing-library": "^0.0.14-next.2",
+        "@tanstack/react-query-devtools": "^5.14.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -5867,6 +5869,57 @@
       ],
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.14.1.tgz",
+      "integrity": "sha512-TlZarySCVEiap4K7BCvrsYZnX7jBbEkR55YMrk8ELcRbuAx6ydL+qoxqUt8Fq8VMvQyGt52icn6T7eJL1Q35KQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.13.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.13.5.tgz",
+      "integrity": "sha512-effSYz9AWcZ6sNd+c8LCBYFIuDZApoCTXEpRlEYChBZpMz9QUUVMLToThwCyUY49+T5pANL3XxgZf3HV7hwJlg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.14.1.tgz",
+      "integrity": "sha512-v7jhe/3jhChiR0XJbGHaG5WNPd/cURwzDGBCr4rzpUTeudPzxrtVRKsF1xJRLcJK3qH/0gIwTYHIPZ3gj+01Yw==",
+      "dependencies": {
+        "@tanstack/query-core": "5.14.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.14.1.tgz",
+      "integrity": "sha512-8fuQs0AMQk8D66JUYqdYA33fOObevuWwm1atOnPbtV8PvIscaU0i/cNTqCl1Y10rgbR/QsqxQSJGBZ5TxxBrlA==",
+      "dev": true,
+      "dependencies": {
+        "@tanstack/query-devtools": "5.13.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.14.1",
+        "react": "^18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@tanstack/react-query": "^5.14.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1",
@@ -33,6 +34,7 @@
     "@storybook/react": "^7.0.27",
     "@storybook/react-webpack5": "^7.0.27",
     "@storybook/testing-library": "^0.0.14-next.2",
+    "@tanstack/react-query-devtools": "^5.14.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/frontend/src/features/comments/components/CommentList.tsx
+++ b/frontend/src/features/comments/components/CommentList.tsx
@@ -1,12 +1,10 @@
-import { useEffect } from 'react';
 import { styled } from 'styled-components';
 import cancelIcon from '@/assets/icon/cancel.svg';
 import BottomSheet from '@/shared/components/BottomSheet/BottomSheet';
 import useModal from '@/shared/components/Modal/hooks/useModal';
 import Spacing from '@/shared/components/Spacing';
 import SRHeading from '@/shared/components/SRHeading';
-import useFetch from '@/shared/hooks/useFetch';
-import { getComments } from '../remotes/comments';
+import { useCommentsQuery } from '../queries';
 import Comment from './Comment';
 import CommentForm from './CommentForm';
 
@@ -17,13 +15,7 @@ interface CommentListProps {
 
 const CommentList = ({ songId, partId }: CommentListProps) => {
   const { isOpen, openModal, closeModal } = useModal(false);
-  const { data: comments, fetchData: refetchComments } = useFetch(() =>
-    getComments(songId, partId)
-  );
-
-  useEffect(() => {
-    refetchComments();
-  }, [partId]);
+  const { comments } = useCommentsQuery(songId, partId);
 
   if (!comments) {
     return null;
@@ -66,7 +58,7 @@ const CommentList = ({ songId, partId }: CommentListProps) => {
           ))}
         </Comments>
         <Spacing direction="vertical" size={8} />
-        <CommentForm getComments={refetchComments} songId={songId} partId={partId} />
+        <CommentForm songId={songId} partId={partId} />
       </BottomSheet>
     </>
   );

--- a/frontend/src/features/comments/queries/index.ts
+++ b/frontend/src/features/comments/queries/index.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getComments, postComment } from '../remotes/comments';
+
+export const useCommentsQuery = (songId: number, partId: number) => {
+  const { data: comments, ...queries } = useQuery({
+    queryKey: ['comments', songId, partId],
+    queryFn: () => getComments(songId, partId),
+  });
+
+  return { comments, queries };
+};
+
+export const usePostCommentMutation = () => {
+  const client = useQueryClient();
+
+  const { mutate: postNewComment, ...mutations } = useMutation({
+    mutationFn: postComment,
+    onSuccess: (_, { songId, partId }) => {
+      client.invalidateQueries({ queryKey: ['comments', songId, partId] });
+    },
+  });
+
+  return { postNewComment, mutations };
+};

--- a/frontend/src/features/comments/remotes/comments.ts
+++ b/frontend/src/features/comments/remotes/comments.ts
@@ -1,7 +1,15 @@
 import { client } from '@/shared/remotes/axios';
 import type { Comment } from '../types/comment.type';
 
-export const postComment = async (songId: number, partId: number, content: string) => {
+export const postComment = async ({
+  songId,
+  partId,
+  content,
+}: {
+  songId: number;
+  partId: number;
+  content: string;
+}) => {
   await client.post(`/songs/${songId}/parts/${partId}/comments`, { content });
 };
 

--- a/frontend/src/features/songs/hooks/useExtraSongDetail.ts
+++ b/frontend/src/features/songs/hooks/useExtraSongDetail.ts
@@ -1,31 +1,33 @@
 import { useCallback, useRef } from 'react';
-import useExtraFetch from '@/shared/hooks/useExtraFetch';
 import useValidParams from '@/shared/hooks/useValidParams';
 import createObserver from '@/shared/utils/createObserver';
-import { getExtraNextSongDetails, getExtraPrevSongDetails } from '../remotes/songs';
+import {
+  useExtraNextSongDetailsInfiniteQuery,
+  useExtraPrevSongDetailsInfiniteQuery,
+} from '../queries';
 import type { Genre } from '../types/Song.type';
 
 const useExtraSongDetail = () => {
-  const { genre: genreParams } = useValidParams();
+  const { id: songIdParams, genre: genreParams } = useValidParams();
 
-  const { data: extraPrevSongDetails, fetchData: fetchExtraPrevSongDetails } = useExtraFetch(
-    getExtraPrevSongDetails,
-    'prev'
-  );
+  const {
+    extraPrevSongDetails,
+    fetchExtraPrevSongDetails,
+    infiniteQueries: { isLoading: isLoadingPrevSongDetails, hasPreviousPage },
+  } = useExtraPrevSongDetailsInfiniteQuery(Number(songIdParams), genreParams as Genre);
 
-  const { data: extraNextSongDetails, fetchData: fetchExtraNextSongDetails } = useExtraFetch(
-    getExtraNextSongDetails,
-    'next'
-  );
+  const {
+    extraNextSongDetails,
+    fetchExtraNextSongDetails,
+    infiniteQueries: { isLoading: isLoadingNextSongDetails, hasNextPage },
+  } = useExtraNextSongDetailsInfiniteQuery(Number(songIdParams), genreParams as Genre);
 
   const prevObserverRef = useRef<IntersectionObserver | null>(null);
   const nextObserverRef = useRef<IntersectionObserver | null>(null);
 
   const getExtraPrevSongDetailsOnObserve: React.RefCallback<HTMLDivElement> = useCallback((dom) => {
     if (dom !== null) {
-      prevObserverRef.current = createObserver(() =>
-        fetchExtraPrevSongDetails(getFirstSongId(dom), genreParams as Genre)
-      );
+      prevObserverRef.current = createObserver(() => fetchExtraPrevSongDetails());
 
       prevObserverRef.current.observe(dom);
       return;
@@ -36,9 +38,7 @@ const useExtraSongDetail = () => {
 
   const getExtraNextSongDetailsOnObserve: React.RefCallback<HTMLDivElement> = useCallback((dom) => {
     if (dom !== null) {
-      nextObserverRef.current = createObserver(() =>
-        fetchExtraNextSongDetails(getLastSongId(dom), genreParams as Genre)
-      );
+      nextObserverRef.current = createObserver(() => fetchExtraNextSongDetails());
 
       nextObserverRef.current.observe(dom);
       return;
@@ -47,21 +47,13 @@ const useExtraSongDetail = () => {
     nextObserverRef.current?.disconnect();
   }, []);
 
-  const getFirstSongId = (dom: HTMLDivElement) => {
-    const firstSongId = dom.nextElementSibling?.getAttribute('data-song-id') as string;
-
-    return Number(firstSongId);
-  };
-
-  const getLastSongId = (dom: HTMLDivElement) => {
-    const lastSongId = dom.previousElementSibling?.getAttribute('data-song-id') as string;
-
-    return Number(lastSongId);
-  };
-
   return {
     extraPrevSongDetails,
     extraNextSongDetails,
+    isLoadingPrevSongDetails,
+    isLoadingNextSongDetails,
+    hasPreviousPage,
+    hasNextPage,
     getExtraPrevSongDetailsOnObserve,
     getExtraNextSongDetailsOnObserve,
   };

--- a/frontend/src/features/songs/hooks/useSongDetailEntries.ts
+++ b/frontend/src/features/songs/hooks/useSongDetailEntries.ts
@@ -1,21 +1,21 @@
 import { useCallback } from 'react';
-import useFetch from '@/shared/hooks/useFetch';
 import useValidParams from '@/shared/hooks/useValidParams';
-import { getSongDetailEntries } from '../remotes/songs';
+import { useSongDetailEntriesQuery } from '../queries';
 import type { Genre } from '../types/Song.type';
 
 const useSongDetailEntries = () => {
   const { id: songIdParams, genre: genreParams } = useValidParams();
 
-  const { data: songDetailEntries } = useFetch(() =>
-    getSongDetailEntries(Number(songIdParams), genreParams as Genre)
-  );
+  const {
+    songDetailEntries,
+    queries: { isLoading: isLoadingSongDetailEntries },
+  } = useSongDetailEntriesQuery(Number(songIdParams), genreParams as Genre);
 
   const scrollIntoCurrentSong: React.RefCallback<HTMLDivElement> = useCallback((dom) => {
     if (dom !== null) dom.scrollIntoView({ behavior: 'instant', block: 'start' });
   }, []);
 
-  return { songDetailEntries, scrollIntoCurrentSong };
+  return { songDetailEntries, isLoadingSongDetailEntries, scrollIntoCurrentSong };
 };
 
 export default useSongDetailEntries;

--- a/frontend/src/features/songs/queries/index.ts
+++ b/frontend/src/features/songs/queries/index.ts
@@ -1,0 +1,50 @@
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import {
+  getExtraNextSongDetails,
+  getExtraPrevSongDetails,
+  getSongDetailEntries,
+} from '../remotes/songs';
+import type { Genre } from '../types/Song.type';
+
+export const useSongDetailEntriesQuery = (songId: number, genre: Genre) => {
+  const { data: songDetailEntries, ...queries } = useQuery({
+    queryKey: ['songDetailEntries'],
+    queryFn: () => getSongDetailEntries(songId, genre),
+    staleTime: Infinity,
+  });
+
+  return { songDetailEntries, queries };
+};
+
+export const useExtraPrevSongDetailsInfiniteQuery = (songId: number, genre: Genre) => {
+  const {
+    data: extraPrevSongDetails,
+    fetchPreviousPage: fetchExtraPrevSongDetails,
+    ...infiniteQueries
+  } = useInfiniteQuery({
+    queryKey: ['extraPrevSongDetails'],
+    queryFn: ({ pageParam }) => getExtraPrevSongDetails(pageParam, genre),
+    getPreviousPageParam: (firstPage) => firstPage[0]?.id ?? null,
+    getNextPageParam: () => null,
+    initialPageParam: songId,
+    staleTime: Infinity,
+  });
+
+  return { extraPrevSongDetails, fetchExtraPrevSongDetails, infiniteQueries };
+};
+
+export const useExtraNextSongDetailsInfiniteQuery = (songId: number, genre: Genre) => {
+  const {
+    data: extraNextSongDetails,
+    fetchNextPage: fetchExtraNextSongDetails,
+    ...infiniteQueries
+  } = useInfiniteQuery({
+    queryKey: ['extraNextSongDetails'],
+    queryFn: ({ pageParam }) => getExtraNextSongDetails(pageParam, genre),
+    getNextPageParam: (lastPage) => lastPage.at(-1)?.id ?? null,
+    initialPageParam: songId,
+    staleTime: Infinity,
+  });
+
+  return { extraNextSongDetails, fetchExtraNextSongDetails, infiniteQueries };
+};

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,3 +1,5 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
@@ -8,6 +10,8 @@ import { loadIFrameApi } from './features/youtube/remotes/loadIframeApi';
 import router from './router';
 import ToastProvider from './shared/components/Toast/ToastProvider';
 import theme from './shared/styles/theme';
+
+const queryClient = new QueryClient();
 
 async function main() {
   if (process.env.NODE_ENV === 'development') {
@@ -30,9 +34,12 @@ async function main() {
       <AuthProvider>
         <GlobalStyles />
         <ThemeProvider theme={theme}>
-          <ToastProvider>
-            <RouterProvider router={router} />
-          </ToastProvider>
+          <QueryClientProvider client={queryClient}>
+            <ToastProvider>
+              <RouterProvider router={router} />
+            </ToastProvider>
+            <ReactQueryDevtools />
+          </QueryClientProvider>
         </ThemeProvider>
       </AuthProvider>
     </React.StrictMode>

--- a/frontend/src/mocks/handlers/songsHandlers.ts
+++ b/frontend/src/mocks/handlers/songsHandlers.ts
@@ -9,13 +9,21 @@ import type { KillingPartPostRequest } from '@/shared/types/killingPart';
 
 const { BASE_URL } = process.env;
 
+const mockComments = [...comments];
+
 const songsHandlers = [
   rest.get(`${BASE_URL}/songs/:songId/parts/:partId/comments`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(comments));
+    return res(ctx.status(200), ctx.json(mockComments));
   }),
 
   rest.post(`${BASE_URL}/songs/:songId/parts/:partId/comments`, async (req, res, ctx) => {
-    return res(ctx.status(201));
+    mockComments.push({
+      id: 123123124124,
+      content: '댓글 추가 목데이터 테스트입니다.',
+      createdAt: new Date().toISOString(),
+      writerNickname: '목데이터',
+    });
+    return res(ctx.status(201), ctx.delay(1000));
   }),
 
   rest.post(`${BASE_URL}/songs/:songId/parts`, async (req, res, ctx) => {
@@ -49,7 +57,7 @@ const songsHandlers = [
 
   rest.get(`${BASE_URL}/songs/high-liked/:songId`, (req, res, ctx) => {
     // const genre = req.url.searchParams.get('genre')
-    return res(ctx.status(200), ctx.json(songEntries));
+    return res(ctx.status(200), ctx.json(songEntries), ctx.delay(1000));
   }),
 
   rest.get(`${BASE_URL}/songs/high-liked/:songId/prev`, (req, res, ctx) => {
@@ -59,7 +67,7 @@ const songsHandlers = [
     const targetIdx = extraPrevSongDetails.findIndex((song) => song.id === Number(songId));
     const sliced = extraPrevSongDetails.slice(0, targetIdx);
 
-    return res(ctx.status(200), ctx.json(sliced));
+    return res(ctx.status(200), ctx.json(sliced), ctx.delay(1000));
   }),
 
   rest.get(`${BASE_URL}/songs/high-liked/:songId/next`, (req, res, ctx) => {
@@ -70,7 +78,7 @@ const songsHandlers = [
     const targetIdx = extraNextSongDetails.findIndex((song) => song.id === Number(songId));
     const sliced = extraNextSongDetails.slice(targetIdx);
 
-    return res(ctx.status(200), ctx.json(sliced));
+    return res(ctx.status(200), ctx.json(sliced), ctx.delay(1000));
   }),
 
   rest.get(`${BASE_URL}/songs/recent`, (req, res, ctx) => {

--- a/frontend/src/pages/SongDetailListPage.tsx
+++ b/frontend/src/pages/SongDetailListPage.tsx
@@ -17,13 +17,20 @@ const SongDetailListPage = () => {
   const {
     extraPrevSongDetails,
     extraNextSongDetails,
+    isLoadingNextSongDetails,
+    isLoadingPrevSongDetails,
+    hasPreviousPage,
+    hasNextPage,
     getExtraPrevSongDetailsOnObserve,
     getExtraNextSongDetailsOnObserve,
   } = useExtraSongDetail();
 
-  if (!songDetailEntries) return null;
+  // Suspense 적용시 워터폴 문제 해결 후 Suspense 적용
+  // 적용 시 아래 분기문 사라짐.
+  if (!songDetailEntries || isLoadingNextSongDetails || isLoadingPrevSongDetails) return null;
 
-  const { prevSongs, currentSong, nextSongs } = songDetailEntries;
+  // 응답값의 prev, next 사용하지 않게 되었음.
+  const { currentSong } = songDetailEntries;
 
   const closeCoachMark = () => {
     setOnboarding(false);
@@ -51,25 +58,35 @@ const SongDetailListPage = () => {
       )}
 
       <ItemContainer>
-        <ObservingTrigger ref={getExtraPrevSongDetailsOnObserve} aria-hidden="true" />
+        {hasPreviousPage && (
+          <ObservingTrigger ref={getExtraPrevSongDetailsOnObserve} aria-hidden="true" />
+        )}
+        {extraPrevSongDetails?.pages.map((details) =>
+          details.map((extraPrevSongDetail) => (
+            <SongDetailItem key={extraPrevSongDetail.id} {...extraPrevSongDetail} />
+          ))
+        )}
 
-        {extraPrevSongDetails?.map((extraPrevSongDetail) => (
-          <SongDetailItem key={extraPrevSongDetail.id} {...extraPrevSongDetail} />
-        ))}
-        {prevSongs.map((prevSongDetail) => (
+        {/* 응답값의 prev, next 사용하지 않게 되었음. */}
+        {/* {prevSongs.map((prevSongDetail) => (
           <SongDetailItem key={prevSongDetail.id} {...prevSongDetail} />
-        ))}
+        ))} */}
 
         <SongDetailItem ref={scrollIntoCurrentSong} key={currentSong.id} {...currentSong} />
 
-        {nextSongs.map((nextSongDetail) => (
+        {/* 응답값의 prev, next 사용하지 않게 되었음. */}
+        {/* {nextSongs.map((nextSongDetail) => (
           <SongDetailItem key={nextSongDetail.id} {...nextSongDetail} />
-        ))}
-        {extraNextSongDetails?.map((extraNextSongDetail) => (
-          <SongDetailItem key={extraNextSongDetail.id} {...extraNextSongDetail} />
-        ))}
+        ))} */}
 
-        <ObservingTrigger ref={getExtraNextSongDetailsOnObserve} aria-hidden="true" />
+        {extraNextSongDetails?.pages.map((details) =>
+          details.map((extraNextSongDetail) => (
+            <SongDetailItem key={extraNextSongDetail.id} {...extraNextSongDetail} />
+          ))
+        )}
+        {hasNextPage && (
+          <ObservingTrigger ref={getExtraNextSongDetailsOnObserve} aria-hidden="true" />
+        )}
       </ItemContainer>
     </>
   );


### PR DESCRIPTION
## 📝작업 내용

### 스와이프 마이그레이션

- useExtraFetch -> useInfiniteQuery 대체
- useFetch -> useQuery 대체

현재 스와이프 페이지 내에서 총 3개의 get 요청을 하고있는데요! 지금의 api 구조로는 2개의 useInfiniteQuery 사용이 불가피했습니다.
또한 페이지에 suspense 적용을 고려했지만, api 워터폴현상이 발생해서 적용하지 못했습니다
(추후 각 api별 컴포넌트 분리가 이뤄지거나, 혹은 api변경이 이루어져서 1개의 infiniteQuery로만 해결 가능해지면, Suspense적용이 가능할것 같습니다.)

useInfiniteQuery의 초기 fetch 시 사용할 pageNumber를 defaultPageParam으로 줄 수 있는데요!
사용자가 선택한 노래(currentSong)의 id를 위, 아래방향 useInfiniteQuery에 defaultPageParam으로 넘겨 해결했습니다.
(이 과정에서 prev, nextSongs 배열은 사용하지 않게 되었습니다.)


### 댓글 마이그레이션

mutaion에 대한 onSuccess는 useMutaion 사용시, mutate 함수 사용시 적용 가능합니다.
이때 순서는 useMutation -> mutate 함수 순으로 실행됩니다.
때문에 query cache 무효화 관련 로직은 useMutation 사용처에 작성했고,
UI관련(토스트 띄우기, 컴포넌트 상태 초기화 등등)은 mutate 함수 사용처에서 작성했습니다.


## #️⃣연관된 이슈

close #558 


